### PR TITLE
Revert "Fix PR1 on 64-bit, not checked against KTX"

### DIFF
--- a/src/bothdefs.h
+++ b/src/bothdefs.h
@@ -256,7 +256,7 @@ void	*Q_calloc (size_t n, size_t size);
 
 char	*Q_strdup (const char *src);
 
-void	COM_StripExtension (const char *str);
+char	*COM_StripExtension (char *str);
 char	*COM_FileExtension (const char *in);
 void	COM_DefaultExtension (char *path, const char *extension);
 

--- a/src/bothtools.c
+++ b/src/bothtools.c
@@ -579,13 +579,15 @@ char *Q_strdup (const char *src)
 COM_StripExtension
 ============
 */
-void COM_StripExtension (const char *str)
+char *COM_StripExtension (char *str)
 {
 	char *p = strrchr(str, '.');
 
     /* truncate extension */
     if (p)
         *p = '\0';
+
+    return str;
 }
 
 /*

--- a/src/common.c
+++ b/src/common.c
@@ -974,7 +974,7 @@ void Info_RemoveKey (char *s, const char *key)
 
 		if (!strncmp (key, pkey, sizeof(pkey)) )
 		{
-			strcpy (start, s);	// remove this part
+			memmove (start, s, strlen(s) + 1);	// remove this part
 			return;
 		}
 

--- a/src/pr2_vm.h
+++ b/src/pr2_vm.h
@@ -45,7 +45,7 @@
 
 typedef union pr2val_s
 {
-	intptr_t	string;
+	string_t	string;
 	float		_float;
 	intptr_t	_int;
 } pr2val_t;	

--- a/src/pr_comp.h
+++ b/src/pr_comp.h
@@ -23,8 +23,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // this file is shared by quake and qcc
 
-typedef int func_t;
-typedef int string_t;
+typedef intptr_t func_t;
+typedef intptr_t string_t;
 
 typedef enum {ev_void, ev_string, ev_float, ev_vector, ev_entity, ev_field, ev_function, ev_pointer} etype_t;
 

--- a/tools/qwdtools/source/init.c
+++ b/tools/qwdtools/source/init.c
@@ -599,7 +599,7 @@ void Load_ini (void)
 	else
 		strlcpy(name, com_argv[0], sizeof(name));
 
-	COM_StripExtension(name, name);
+	COM_StripExtension(name);
 	ForceExtension(name, ".ini");
 
 	//Sys_Printf("name:%s\nargv:%s\n", name, com_argv[0]);

--- a/tools/qwdtools/source/tools.c
+++ b/tools/qwdtools/source/tools.c
@@ -795,7 +795,7 @@ char *TemplateName (char *from1, char *to, char *ch)
 	if ( !(p = strstr(to, ch)) )
 		return to;
 
-    strlcpy(tmp, from1, sizeof(tmp));
+	strlcpy(tmp, from1, sizeof(tmp));
 	COM_StripExtension(tmp);
 	strlcpy(name, to, p - to);
 	strlcat(name, va("%s%s", tmp, p + 1), sizeof(name));

--- a/tools/qwdtools/source/tools.c
+++ b/tools/qwdtools/source/tools.c
@@ -795,7 +795,8 @@ char *TemplateName (char *from1, char *to, char *ch)
 	if ( !(p = strstr(to, ch)) )
 		return to;
 
-	COM_StripExtension(from1, tmp);
+    strlcpy(tmp, from1, sizeof(tmp));
+	COM_StripExtension(tmp);
 	strlcpy(name, to, p - to);
 	strlcat(name, va("%s%s", tmp, p + 1), sizeof(name));
 


### PR DESCRIPTION
This reverts commit b4a6d7a20e18f78babd6ac9fcb5efd1e615eec28.
This commit breaks KTX support and likely cause more problems as
pointed by @qqshka.