### PR TITLE
ENTITY FILES: Add cvar sv_entityfile to support multiple .ent files/map

### DIFF
--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -224,7 +224,7 @@ void SV_SpawnServer (char *mapname, qbool devmap)
 	edict_t *ent;
 	int i;
 
-	extern cvar_t sv_loadentfiles, sv_loadentfiles_dir;
+	extern cvar_t sv_loadentfiles, sv_loadentfiles_dir, sv_entityfile;
 	char *entitystring;
 	char oldmap[MAP_NAME_LEN];
 	extern qbool	sv_allow_cheats;
@@ -495,17 +495,24 @@ void SV_SpawnServer (char *mapname, qbool devmap)
 	if ((int)sv_loadentfiles.value)
 	{
 		char ent_path[1024] = {0};
+		char* ent_filename = sv.mapname;
+
+		if (strstr(sv_entityfile.string, sv.mapname) == sv_entityfile.string)
+			ent_filename = sv_entityfile.string;
+		else
+			Cvar_Set(&sv_entityfile, "");
+
 		// first try maps/sv_loadentfiles_dir/
 		if (sv_loadentfiles_dir.string[0])
 		{
-			snprintf(ent_path, sizeof(ent_path), "maps/%s/%s.ent", sv_loadentfiles_dir.string, sv.mapname);
+			snprintf(ent_path, sizeof(ent_path), "maps/%s/%s.ent", sv_loadentfiles_dir.string, ent_filename);
 			entitystring = (char *) FS_LoadHunkFile(ent_path, NULL);
 		}
 
 		// try maps/ if not loaded yet.
 		if (!entitystring)
 		{
-			snprintf(ent_path, sizeof(ent_path), "maps/%s.ent", sv.mapname);
+			snprintf(ent_path, sizeof(ent_path), "maps/%s.ent", ent_filename);
 			entitystring = (char *) FS_LoadHunkFile(ent_path, NULL);
 		}
 

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -135,6 +135,7 @@ cvar_t	sv_serverip = {"sv_serverip", ""};
 cvar_t	sv_forcespec_onfull = {"sv_forcespec_onfull", "2"};
 cvar_t	sv_maxdownloadrate = {"sv_maxdownloadrate", "0"};
 
+cvar_t  sv_entityfile = {"sv_entityfile", "", CVAR_SERVERINFO};	// If specified, use that .ent filename - otherwise default to mapname.ent.  Will be reset back to "" if name doesn't start with mapname
 cvar_t  sv_loadentfiles = {"sv_loadentfiles", "1"}; //loads .ent files by default if there
 cvar_t  sv_loadentfiles_dir = {"sv_loadentfiles_dir", ""}; // check for .ent file in maps/sv_loadentfiles_dir first then just maps/
 cvar_t	sv_default_name = {"sv_default_name", "unnamed"};
@@ -3345,6 +3346,7 @@ void SV_InitLocal (void)
 	Cvar_Register (&sv_maxrate);
 	Cvar_Register (&sv_loadentfiles);
 	Cvar_Register (&sv_loadentfiles_dir);
+	Cvar_Register (&sv_entityfile);
 	Cvar_Register (&sv_default_name);
 	Cvar_Register (&sv_mod_msg_file);
 	Cvar_Register (&sv_forcenick);


### PR DESCRIPTION
Default behaviour is to load mapname.ent file.  To allow multiple .ent
files to be supported for one map, this field can be set to the name of
the file before changing the level.

The entity file will only be loaded if it starts with the name of the map
being loaded, and will be cleared if it doesn't match the map being loaded.

This makes sure we don't cause the server to keep spawning one map's
entities after a map change.  Any mod setting sv_entityfile should be
aware of this and responsible for keeping the combination of sv_entityfile
and map correct, but this gives a bit of protection for anyone directly
typing "map x" at the console.