### PR TITLE
MAP: Allow user to specify entity file to load when changing map

### DIFF
--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1650,6 +1650,7 @@ void PF2_changelevel(byte* base, uintptr_t mask, pr2val_t* stack, pr2val_t*retva
 {
 	static int last_spawncount;
 	char *s = (char *) VM_POINTER(base,mask,stack[0].string);
+	char *entfile = (char *) VM_POINTER(base,mask,stack[1].string);
 	char expanded[MAX_QPATH];
 
 	// check to make sure the level exists.
@@ -1668,7 +1669,10 @@ void PF2_changelevel(byte* base, uintptr_t mask, pr2val_t* stack, pr2val_t*retva
 		return;
 	last_spawncount = svs.spawncount;
 
-	Cbuf_AddText(va("map %s\n", s));
+	if (entfile && *entfile)
+		Cbuf_AddText(va("map %s %s\n", s, entfile));
+	else
+		Cbuf_AddText(va("map %s\n", s));
 }
 
 /*

--- a/src/server.h
+++ b/src/server.h
@@ -769,7 +769,7 @@ int SV_GenerateUserID (void);
 //
 int SV_ModelIndex (char *name);
 void SV_FlushSignon (void);
-void SV_SpawnServer (char *server, qbool devmap);
+void SV_SpawnServer (char *server, qbool devmap, char* entityfile);
 
 
 //

--- a/src/sv_ccmds.c
+++ b/src/sv_ccmds.c
@@ -406,9 +406,10 @@ command from the console or progs.
 */
 void SV_Map (qbool now)
 {
-	static char	level[MAX_QPATH];
-	static char	expanded[MAX_QPATH];
-	static qbool changed = false;
+	static char     level[MAX_QPATH];
+	static char     expanded[MAX_QPATH];
+	static char     entityfile[MAX_QPATH];
+	static qbool    changed = false;
 
 	char	*s;
 
@@ -455,7 +456,7 @@ void SV_Map (qbool now)
 		}
 		// <-
 
-		SV_SpawnServer (level, !strcasecmp(Cmd_Argv(0), "devmap"));
+		SV_SpawnServer (level, !strcasecmp(Cmd_Argv(0), "devmap"), entityfile);
 
 		SV_BroadcastCommand ("changing\n"
 							 "reconnect\n");
@@ -466,13 +467,17 @@ void SV_Map (qbool now)
 
 	// get the map name, but don't change now, could be executed from progs.dat
 
-	if (Cmd_Argc() != 2)
+	if (Cmd_Argc() < 2 || Cmd_Argc() > 3)
 	{
-		Con_Printf ("map <levelname> : continue game on a new level\n");
+		Con_Printf ("map <levelname> [<entityfile>] : continue game on a new level\n");
 		return;
 	}
 
 	strlcpy (level, Cmd_Argv(1), MAX_QPATH);
+
+	memset(entityfile, 0, sizeof(entityfile));
+	if (Cmd_Argc() >= 3)
+		strlcpy (entityfile, Cmd_Argv(2), MAX_QPATH);
 
 	// check to make sure the level exists
 	snprintf (expanded, MAX_QPATH, "maps/%s.bsp", level);

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -217,7 +217,7 @@ clients along with it.
 This is only called from the SV_Map_f() function.
 ================
 */
-void SV_SpawnServer (char *mapname, qbool devmap)
+void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 {
 	extern func_t ED_FindFunctionOffset (char *name);
 
@@ -495,17 +495,21 @@ void SV_SpawnServer (char *mapname, qbool devmap)
 	if ((int)sv_loadentfiles.value)
 	{
 		char ent_path[1024] = {0};
+
+		if (!entityfile || !entityfile[0])
+			entityfile = sv.mapname;
+
 		// first try maps/sv_loadentfiles_dir/
 		if (sv_loadentfiles_dir.string[0])
 		{
-			snprintf(ent_path, sizeof(ent_path), "maps/%s/%s.ent", sv_loadentfiles_dir.string, sv.mapname);
+			snprintf(ent_path, sizeof(ent_path), "maps/%s/%s.ent", sv_loadentfiles_dir.string, entityfile);
 			entitystring = (char *) FS_LoadHunkFile(ent_path, NULL);
 		}
 
 		// try maps/ if not loaded yet.
 		if (!entitystring)
 		{
-			snprintf(ent_path, sizeof(ent_path), "maps/%s.ent", sv.mapname);
+			snprintf(ent_path, sizeof(ent_path), "maps/%s.ent", entityfile);
 			entitystring = (char *) FS_LoadHunkFile(ent_path, NULL);
 		}
 

--- a/src/sv_save.c
+++ b/src/sv_save.c
@@ -221,7 +221,7 @@ void SV_LoadGame_f (void) {
 	CL_BeginLocalConnection ();
 #endif
 
-	SV_SpawnServer (mapname, false);
+	SV_SpawnServer (mapname, false, NULL);
 
 	if (sv.state != ss_active) {
 		Con_Printf ("Couldn't load map\n");


### PR DESCRIPTION
Optional second parameter to "map" command, if not specified then server
defaults back to loading <mapname>.ent instead.

This lets users/mods support multiple .ent files for each map.