### PR TITLE
MVDSV changes

### DIFF
--- a/build/make/Makefile.BSD
+++ b/build/make/Makefile.BSD
@@ -91,7 +91,9 @@ SV_OBJS = \
 		${SV_DIR}/zone.o \
 \
 		${SV_DIR}/pcre/get.o \
-		${SV_DIR}/pcre/pcre.o
+		${SV_DIR}/pcre/pcre.o \
+\
+		${SV_DIR}/central.o
 
 .ifdef USE_ASM
 SV_ASM_OBJS = \

--- a/build/make/Makefile.GNU
+++ b/build/make/Makefile.GNU
@@ -43,6 +43,11 @@ CFLAGS+= -DBSD_COMP
 endif
 endif
 
+CURL_CFLAGS ?= $(shell pkg-config libcurl --cflags)
+CURL_LIBS ?= $(shell pkg-config libcurl --libs)
+CFLAGS += $(CURL_CFLAGS)
+LDFLAGS += $(CURL_LIBS)
+
 ifeq ($(CC_BASEVERSION),4) # if gcc4 then build universal binary
 ifeq ($(UNAME),Darwin)
 CFLAGS+= -arch ppc -arch i386
@@ -106,7 +111,9 @@ SV_OBJS = \
 		$(SV_DIR)/zone.o \
 \
 		$(SV_DIR)/pcre/get.o \
-		$(SV_DIR)/pcre/pcre.o
+		$(SV_DIR)/pcre/pcre.o \
+\
+		$(SV_DIR)/central.o
 
 ifeq ($(USE_ASM),$(ASM))
 SV_ASM_OBJS = \

--- a/build/make/Makefile.GNU
+++ b/build/make/Makefile.GNU
@@ -14,39 +14,58 @@ SV_DIR = ../../src
 # for gcc its like: make mvdsv FORCE32BITFLAGS=-m32
 # configure script add FORCE32BITFLAGS=-m32
 
-BASE_CFLAGS=-Wall -pipe -pthread -funsigned-char -DSERVERONLY -DUSE_PR2 -D$(BYTE_ORDER)Q__ $(FORCE32BITFLAGS)
+BASE_CFLAGS=-Wall -pipe -funsigned-char -DSERVERONLY -DUSE_PR2 -D$(BYTE_ORDER)Q__ $(FORCE32BITFLAGS)
 WITH_OPTIMIZED_CFLAGS=YES
+
+# libcurl support
+ifeq ($(shell pkg-config --exists libcurl && echo 1),1)
+	CURL_CFLAGS = `pkg-config libcurl --cflags`
+	CURL_LIBS = `pkg-config libcurl --libs`
+endif
 
 USE_ASM=-Did386
 ifeq ($(WITH_OPTIMIZED_CFLAGS),YES)
-ifeq ($(ARCH),x86)
-ifneq ($(UNAME),Darwin)
-ifneq ($(UNAME),MacOSX)
-ASM=$(USE_ASM)
-endif
-endif
-endif
-CFLAGS=$(ASM) $(BASE_CFLAGS) -O2 -fno-strict-aliasing -ffast-math -funroll-loops
+	ifeq ($(ARCH),x86)
+		ifneq ($(UNAME),Darwin)
+			ifneq ($(UNAME),MacOSX)
+				ASM=$(USE_ASM)
+			endif
+		endif
+	endif
+	CFLAGS=$(ASM) $(BASE_CFLAGS) -O2 -fno-strict-aliasing -ffast-math -funroll-loops
 else
-CFLAGS=$(BASE_CFLAGS) -Wsign-compare -ggdb
+	CFLAGS=$(BASE_CFLAGS) -Wsign-compare -ggdb
 endif
 
 LDFLAGS=-lm
+ASMFLAGS=-DELF -x assembler-with-cpp
 ifeq ($(UNAME),Linux)
-LDFLAGS+=-ldl
-STRIP=-strip
-STRIP_FLAGS=--strip-unneeded --remove-section=.comment mvdsv
+	LDFLAGS+=-ldl
+	CFLAGS+= -pthread
+	STRIP=-strip
+	STRIP_FLAGS=--strip-unneeded --remove-section=.comment mvdsv
 else
-ifeq ($(UNAME),SunOS)
-LDFLAGS+= -lsocket -lnsl
-CFLAGS+= -DBSD_COMP
-endif
+	ifeq ($(UNAME),SunOS)
+		LDFLAGS+= -lsocket -lnsl
+		CFLAGS+= -pthread -DBSD_COMP
+	else
+		ifeq ($(UNAME),CYGWIN_NT-10.0)
+			LDFLAGS += -Lmingw32-libs/lib -static -lws2_32 -lwinmm
+			CFLAGS += -D_WIN32_WINNT=0x0501 -D_USE_32BIT_TIME_T -D__USE_MINGW_ANSI_STDIO -D_CONSOLE
+			STRIP=-strip
+			STRIP_FLAGS=--strip-unneeded --remove-section=.comment mvdsv
+			ASMFLAGS = -x assembler-with-cpp
+		else
+			CFLAGS+= -pthread 
+		endif
+	endif
 endif
 
-CURL_CFLAGS ?= $(shell pkg-config libcurl --cflags)
-CURL_LIBS ?= $(shell pkg-config libcurl --libs)
-CFLAGS += $(CURL_CFLAGS)
-LDFLAGS += $(CURL_LIBS)
+ifdef CURL_CFLAGS
+	CFLAGS += $(CURL_CFLAGS)
+	CFLAGS += -DWWW_INTEGRATION
+	LDFLAGS += $(CURL_LIBS)
+endif
 
 ifeq ($(CC_BASEVERSION),4) # if gcc4 then build universal binary
 ifeq ($(UNAME),Darwin)
@@ -61,7 +80,7 @@ endif
 # SERVER
 #############################################################################
 
-SV_OBJS = \
+SV_OBJS += \
 		$(SV_DIR)/pr_cmds.o \
 		$(SV_DIR)/pr_edict.o \
 		$(SV_DIR)/pr_exec.o \
@@ -85,7 +104,6 @@ SV_OBJS = \
 		$(SV_DIR)/sv_nchan.o \
 		$(SV_DIR)/sv_phys.o \
 		$(SV_DIR)/sv_send.o \
-		$(SV_DIR)/sv_sys_unix.o \
 		$(SV_DIR)/sv_user.o \
 		$(SV_DIR)/sv_save.o \
 \
@@ -112,8 +130,10 @@ SV_OBJS = \
 \
 		$(SV_DIR)/pcre/get.o \
 		$(SV_DIR)/pcre/pcre.o \
-\
-		$(SV_DIR)/central.o
+
+ifdef CURL_CFLAGS
+		SV_WEB_INTEGRATION = $(SV_DIR)/central.o
+endif
 
 ifeq ($(USE_ASM),$(ASM))
 SV_ASM_OBJS = \
@@ -125,17 +145,31 @@ endif
 # SETUP AND BUILD
 #############################################################################
 
+# Define V=1 to show command line.
+ifdef V
+    Q :=
+    E := @true
+else
+    Q := @
+    E := @echo
+endif
+
 .c.o :
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(E) [CC] $@
+	$(Q)$(CC) $(CFLAGS) -c $< -o $@
 
 .s.o :
-	$(CC) $(CFLAGS) -DELF -x assembler-with-cpp -c $< -o $@
+	$(E) [ASM] $@
+	$(Q)$(CC) $(CFLAGS) $(ASMFLAGS) -c $< -o $@
 
 all : mvdsv
-	$(STRIP) $(STRIP_FLAGS)
+	$(E) [STRIP]
+	$(Q)$(STRIP) $(STRIP_FLAGS)
 
-mvdsv : $(SV_OBJS) $(SV_ASM_OBJS)
-	$(CC) $(CFLAGS) -o mvdsv $^ $(LDFLAGS)
+mvdsv : $(SV_WEB_INTEGRATION) $(SV_OBJS) $(SV_ASM_OBJS)
+	$(E) [LINK]
+	$(Q)$(CC) $(CFLAGS) -o mvdsv $^ $(LDFLAGS)
 
 clean : 
-	-rm -f $(SV_DIR)/core $(SV_DIR)/*.o $(SV_DIR)/pcre/*.o mvdsv
+	$(E) [CLEAN]
+	$(Q)-rm -f $(SV_DIR)/core $(SV_DIR)/*.o $(SV_DIR)/pcre/*.o mvdsv

--- a/build/make/configure
+++ b/build/make/configure
@@ -82,16 +82,22 @@ else
 	return 1
 fi
 
-
 # OS determination
 
 if [ x$1 != x ]; then
-UNAME=$1
+	UNAME=$1
 else
-UNAME=`uname`
+	UNAME=`uname`
 fi
 
 ARCH=`uname -m | sed -e 's/i.86/x86/g' -e 's/Power Macintosh/ppc/g' -e 's/amd64/x86_64/g'`
+
+# on windows, always be 32bit
+if [ ${UNAME} = CYGWIN_NT-10.0 ]; then
+	BITS=32
+	ARCH=x86
+fi
+
 echo UNAME="${UNAME}" >> Makefile
 echo ARCH="${ARCH}" >> Makefile
 
@@ -121,11 +127,19 @@ fi
 case ${UNAME} in
 FreeBSD | OpenBSD | NetBSD | DragonFly | BSD)
 	echo "${UNAME} ${ARCH} ${BITS}bits system - using BSD Makefile."
+	echo "SV_OBJS = \$(SV_DIR)/sv_sys_unix.o" >> Makefile
 	cat Makefile.BSD >> Makefile
+	echo "Configuration completed."
+	;;
+CYGWIN_NT-10.0)
+	echo "${UNAME} ${ARCH} ${BITS}bits system - using GNU Makefile."
+	echo "SV_OBJS = \$(SV_DIR)/sv_sys_win.o" >> Makefile
+	cat Makefile.GNU >> Makefile
 	echo "Configuration completed."
 	;;
 Darwin | MacOSX | Linux | SunOS | GNU)
 	echo "${UNAME} ${ARCH} ${BITS}bits system - using GNU Makefile."
+	echo "SV_OBJS = \$(SV_DIR)/sv_sys_unix.o" >> Makefile
 	cat Makefile.GNU >> Makefile
 	echo "Configuration completed."
 	;;

--- a/build/vs/mvdsv_vc2015.vcxproj
+++ b/build/vs/mvdsv_vc2015.vcxproj
@@ -127,13 +127,13 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;_CRT_DISABLE_PERFCRIT_LOCKS;id386;USE_PR2;SERVERONLY;WITH_NQPROGS;__LITTLE_ENDIAN__Q__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CONSOLE;_DEBUG;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;_CRT_DISABLE_PERFCRIT_LOCKS;id386;USE_PR2;SERVERONLY;WITH_NQPROGS;__LITTLE_ENDIAN__Q__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <ExceptionHandling>
       </ExceptionHandling>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <SmallerTypeCheck>false</SmallerTypeCheck>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <AdditionalOptions> /J</AdditionalOptions>
       <PrecompiledHeader>
@@ -166,7 +166,7 @@
       <GenerateMapFile>true</GenerateMapFile>
       <MapFileName>$(TargetDir)$(TargetName).map</MapFileName>
       <MapExports>false</MapExports>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention>
       </DataExecutionPrevention>

--- a/build/vs/mvdsv_vc2015.vcxproj
+++ b/build/vs/mvdsv_vc2015.vcxproj
@@ -60,6 +60,14 @@
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IncludePath>C:\Projects\quake\mvdsv\dependencies\include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\Projects\quake\mvdsv\dependencies\lib;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IncludePath>C:\Projects\quake\mvdsv\dependencies\include;$(IncludePath)</IncludePath>
+    <LibraryPath>C:\Projects\quake\mvdsv\dependencies\lib;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Midl>
       <TypeLibraryName>Release\mvdsv.tlb</TypeLibraryName>
@@ -99,7 +107,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>wsock32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcurld.lib;wsock32.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>mvdsv.exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -127,7 +135,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_CONSOLE;_DEBUG;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;_CRT_DISABLE_PERFCRIT_LOCKS;id386;USE_PR2;SERVERONLY;WITH_NQPROGS;__LITTLE_ENDIAN__Q__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CURL_STATICLIB;_CONSOLE;_DEBUG;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;_CRT_DISABLE_PERFCRIT_LOCKS;id386;USE_PR2;SERVERONLY;WITH_NQPROGS;__LITTLE_ENDIAN__Q__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <ExceptionHandling>
       </ExceptionHandling>
@@ -172,6 +180,7 @@
       </DataExecutionPrevention>
       <TargetMachine>MachineX86</TargetMachine>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+      <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
     </Link>
     <Manifest>
       <UpdateFileHashes>true</UpdateFileHashes>
@@ -186,6 +195,7 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BrowseInformation Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</BrowseInformation>
     </ClCompile>
+    <ClCompile Include="..\..\src\central.c" />
     <ClCompile Include="..\..\src\cmd.c">
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Disabled</Optimization>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -520,6 +530,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\src\bothdefs.h" />
     <ClInclude Include="..\..\src\bspfile.h" />
+    <ClInclude Include="..\..\src\central.h" />
     <ClInclude Include="..\..\src\cmd.h" />
     <ClInclude Include="..\..\src\cmodel.h" />
     <ClInclude Include="..\..\src\common.h" />

--- a/build/vs/mvdsv_vc2015.vcxproj
+++ b/build/vs/mvdsv_vc2015.vcxproj
@@ -135,7 +135,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>CURL_STATICLIB;_CONSOLE;_DEBUG;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;_CRT_DISABLE_PERFCRIT_LOCKS;id386;USE_PR2;SERVERONLY;WITH_NQPROGS;__LITTLE_ENDIAN__Q__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WWW_INTEGRATION;CURL_STATICLIB;_CONSOLE;_DEBUG;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;_CRT_DISABLE_PERFCRIT_LOCKS;id386;USE_PR2;SERVERONLY;WITH_NQPROGS;__LITTLE_ENDIAN__Q__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <ExceptionHandling>
       </ExceptionHandling>

--- a/src/asm_i386.h
+++ b/src/asm_i386.h
@@ -53,16 +53,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define	hu_clip_maxs		28
 #define hu_size  			40
 
-// dnode_t structure
-// !!! if this is changed, it must be changed in bspfile.h too !!!
-#define	nd_planenum		0
-#define	nd_children		4
-#define	nd_mins			8
-#define	nd_maxs			20
-#define	nd_firstface	32
-#define	nd_numfaces		36
-#define nd_size			40
-
 // sfxcache_t structure
 // !!! if this is changed, it much be changed in qsound.h too !!!
 #define sfxc_length		0

--- a/src/bothdefs.h
+++ b/src/bothdefs.h
@@ -48,11 +48,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //
 // per-level limits
 //
-#define	MAX_EDICTS				512		// FIXME: ouch! ouch! ouch! - trying to fix...
-#define	MAX_LIGHTSTYLES			64
-#define	MAX_MODELS				256		// these are sent over the net as bytes
-#define	MAX_SOUNDS				256		// so they cannot be blindly increased
-#define MAX_VWEP_MODELS			32		// could be increased to 256
+#define	MAX_EDICTS              2048    // can't encode more than this, see SV_WriteDelta
+#define MAX_EDICTS_SAFE         512     // lower limit, to make sure no client limits exceeded
+#define	MAX_LIGHTSTYLES         64
+#define	MAX_MODELS              512     // can't encode more than this, see SV_WriteDelta
+#define	MAX_SOUNDS              256     // so they cannot be blindly increased
+#define MAX_VWEP_MODELS         32      // could be increased to 256
 
 #define	MAX_STYLESTRING			64
 

--- a/src/bspfile.h
+++ b/src/bspfile.h
@@ -25,7 +25,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define	MAX_MAP_HULLS		4
 
-#define	MAX_MAP_MODELS		256
+#define	MAX_MAP_MODELS		512
 #define	MAX_MAP_BRUSHES		4096
 #define	MAX_MAP_ENTITIES	1024
 #define	MAX_MAP_ENTSTRING	65536
@@ -53,8 +53,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //=============================================================================
 
 
-#define Q1_BSPVERSION	29
-#define HL_BSPVERSION	30
+#define Q1_BSPVERSION     29
+#define HL_BSPVERSION     30
+#define Q1_BSPVERSION29a  (('2') + ('P' << 8) + ('S' << 16) + ('B' << 24))
+#define Q1_BSPVERSION2    (('B') + ('S' << 8) + ('P' << 16) + ('2' << 24))
 
 typedef struct
 {
@@ -141,23 +143,53 @@ typedef struct
 #define	CONTENTS_LAVA		-5
 #define	CONTENTS_SKY		-6
 
-// !!! if this is changed, it must be changed in asm_i386.h too !!!
 typedef struct
 {
-	int			planenum;
-	short		children[2];	// negative numbers are -(leafs+1), not nodes
-	short		mins[3];		// for sphere culling
-	short		maxs[3];
-	unsigned short	firstface;
-	unsigned short	numfaces;	// counting both sides
+	int             planenum;
+	short           children[2];    // negative numbers are -(leafs+1), not nodes
+	short           mins[3];        // for sphere culling
+	short           maxs[3];
+	unsigned short  firstface;
+	unsigned short  numfaces;       // counting both sides
 } dnode_t;
 
 typedef struct
 {
-	int			planenum;
-	short		children[2];	// negative numbers are contents
+	int             planenum;
+	int             children[2];    // negative numbers are -(leafs+1), not nodes
+	short           mins[3];        // for sphere culling
+	short           maxs[3];
+	unsigned int    firstface;
+	unsigned int    numfaces;       // counting both sides
+} dnode29a_t;
+
+typedef struct
+{
+	int             planenum;
+	int             children[2];    // negative numbers are -(leafs+1), not nodes
+	float           mins[3];        // for sphere culling
+	float           maxs[3];
+	unsigned int    firstface;
+	unsigned int    numfaces;       // counting both sides
+} dnode_bsp2_t;
+
+typedef struct
+{
+	int         planenum;
+	short       children[2];	// negative numbers are contents
 } dclipnode_t;
 
+typedef struct
+{
+	int         planenum;
+	int         children[2];	// negative numbers are contents
+} dclipnode29a_t;
+
+typedef struct
+{
+	int         planenum;
+	int         children[2];	// negative numbers are contents
+} mclipnode_t;
 
 typedef struct texinfo_s
 {
@@ -171,24 +203,42 @@ typedef struct texinfo_s
 // counterclockwise use of the edge in a face
 typedef struct
 {
-	unsigned short	v[2];		// vertex numbers
+	unsigned short  v[2];       // vertex numbers
 } dedge_t;
+
+typedef struct
+{
+	unsigned int    v[2];       // vertex numbers
+} dedge29a_t;
 
 #define	MAXLIGHTMAPS	4
 typedef struct
 {
-	short		planenum;
-	short		side;
+	short       planenum;
+	short       side;
 
-	int			firstedge;		// we must support > 64k edges
-	short		numedges;	
-	short		texinfo;
+	int         firstedge;      // we must support > 64k edges
+	short       numedges;	
+	short       texinfo;
 
-// lighting info
-	byte		styles[MAXLIGHTMAPS];
-	int			lightofs;		// start of [numstyles*surfsize] samples
+	// lighting info
+	byte        styles[MAXLIGHTMAPS];
+	int         lightofs;       // start of [numstyles*surfsize] samples
 } dface_t;
 
+typedef struct
+{
+	int         planenum;
+	int         side;
+
+	int         firstedge;      // we must support > 64k edges
+	int         numedges;
+	int         texinfo;
+
+	// lighting info
+	byte        styles[MAXLIGHTMAPS];
+	int         lightofs;       // start of [numstyles*surfsize] samples
+} dface29a_t;
 
 
 #define	AMBIENT_WATER	0
@@ -213,5 +263,33 @@ typedef struct
 
 	byte		ambient_level[NUM_AMBIENTS];
 } dleaf_t;
+
+typedef struct
+{
+	int         contents;
+	int         visofs;             // -1 = no visibility info
+
+	short       mins[3];            // for frustum culling
+	short       maxs[3];
+
+	unsigned int    firstmarksurface;
+	unsigned int    nummarksurfaces;
+
+	byte        ambient_level[NUM_AMBIENTS];
+} dleaf29a_t;
+
+typedef struct
+{
+	int         contents;
+	int         visofs;             // -1 = no visibility info
+
+	float       mins[3];            // for frustum culling
+	float       maxs[3];
+
+	unsigned int    firstmarksurface;
+	unsigned int    nummarksurfaces;
+
+	byte        ambient_level[NUM_AMBIENTS];
+} dleaf_bsp2_t;
 
 #endif /* !__BSPFILE_H__ */

--- a/src/bspfile.h
+++ b/src/bspfile.h
@@ -83,37 +83,37 @@ typedef struct
 
 typedef struct
 {
-	float		mins[3], maxs[3];
-	float		origin[3];
-	int			headnode[MAX_MAP_HULLS];
-	int			visleafs;		// not including the solid leaf 0
-	int			firstface, numfaces;
+	float       mins[3], maxs[3];
+	float       origin[3];
+	int	        headnode[MAX_MAP_HULLS];
+	int         visleafs;                    // not including the solid leaf 0
+	int         firstface, numfaces;
 } dmodel_t;
 
 typedef struct
 {
-	int			version;
-	lump_t		lumps[HEADER_LUMPS];
+	int         version;
+	lump_t      lumps[HEADER_LUMPS];
 } dheader_t;
 
 typedef struct
 {
-	int			nummiptex;
-	int			dataofs[4];		// [nummiptex]
+	int         nummiptex;
+	int         dataofs[4];                  // [nummiptex]
 } dmiptexlump_t;
 
 #define	MIPLEVELS	4
 typedef struct miptex_s
 {
-	char		name[16];
-	unsigned	width, height;
-	unsigned	offsets[MIPLEVELS];		// four mip maps stored
+	char        name[16];
+	unsigned    width, height;
+	unsigned    offsets[MIPLEVELS];		// four mip maps stored
 } miptex_t;
 
 
 typedef struct
 {
-	float	point[3];
+	float       point[3];
 } dvertex_t;
 
 
@@ -129,9 +129,9 @@ typedef struct
 
 typedef struct
 {
-	float	normal[3];
-	float	dist;
-	int		type;		// PLANE_X - PLANE_ANYZ ?remove? trivial to regenerate
+	float       normal[3];
+	float       dist;
+	int         type;             // PLANE_X - PLANE_ANYZ ?remove? trivial to regenerate
 } dplane_t;
 
 
@@ -146,7 +146,7 @@ typedef struct
 typedef struct
 {
 	int             planenum;
-	short           children[2];    // negative numbers are -(leafs+1), not nodes
+	short           children[2];	// negative numbers are -(leafs+1), not nodes
 	short           mins[3];        // for sphere culling
 	short           maxs[3];
 	unsigned short  firstface;
@@ -176,44 +176,41 @@ typedef struct
 typedef struct
 {
 	int         planenum;
-	short       children[2];	// negative numbers are contents
+	short       children[2];        // negative numbers are contents
 } dclipnode_t;
 
 typedef struct
 {
 	int         planenum;
-	int         children[2];	// negative numbers are contents
+	int         children[2];        // negative numbers are contents
 } dclipnode29a_t;
 
 typedef struct
 {
 	int         planenum;
-	int         children[2];	// negative numbers are contents
+	int         children[2];        // negative numbers are contents
 } mclipnode_t;
 
 typedef struct texinfo_s
 {
-	float		vecs[2][4];		// [s/t][xyz offset]
+	float		vecs[2][4];         // [s/t][xyz offset]
 	int			miptex;
 	int			flags;
 } texinfo_t;
-#define	TEX_SPECIAL		1		// sky or slime, no lightmap or 256 subdivision
+#define	TEX_SPECIAL		1           // sky or slime, no lightmap or 256 subdivision
 
 // note that edge 0 is never used, because negative edge nums are used for
 // counterclockwise use of the edge in a face
-typedef struct
-{
-	unsigned short  v[2];       // vertex numbers
+typedef struct {
+	unsigned short	v[2];           // vertex numbers
 } dedge_t;
 
-typedef struct
-{
-	unsigned int    v[2];       // vertex numbers
+typedef struct {
+	unsigned int	v[2];           // vertex numbers
 } dedge29a_t;
 
 #define	MAXLIGHTMAPS	4
-typedef struct
-{
+typedef struct {
 	short       planenum;
 	short       side;
 
@@ -226,8 +223,7 @@ typedef struct
 	int         lightofs;       // start of [numstyles*surfsize] samples
 } dface_t;
 
-typedef struct
-{
+typedef struct {
 	int         planenum;
 	int         side;
 
@@ -240,56 +236,52 @@ typedef struct
 	int         lightofs;       // start of [numstyles*surfsize] samples
 } dface29a_t;
 
+#define	AMBIENT_WATER   0
+#define	AMBIENT_SKY     1
+#define	AMBIENT_SLIME   2
+#define	AMBIENT_LAVA    3
 
-#define	AMBIENT_WATER	0
-#define	AMBIENT_SKY		1
-#define	AMBIENT_SLIME	2
-#define	AMBIENT_LAVA	3
-
-#define	NUM_AMBIENTS	4		// automatic ambient sounds
+#define	NUM_AMBIENTS    4       // automatic ambient sounds
 
 // leaf 0 is the generic CONTENTS_SOLID leaf, used for all solid areas
 // all other leafs need visibility info
-typedef struct
-{
-	int			contents;
-	int			visofs;				// -1 = no visibility info
+typedef struct {
+	int            contents;
+	int            visofs;          // -1 = no visibility info
 
-	short		mins[3];			// for frustum culling
-	short		maxs[3];
+	short          mins[3];         // for frustum culling
+	short          maxs[3];
 
-	unsigned short		firstmarksurface;
-	unsigned short		nummarksurfaces;
+	unsigned short firstmarksurface;
+	unsigned short nummarksurfaces;
 
-	byte		ambient_level[NUM_AMBIENTS];
+	byte           ambient_level[NUM_AMBIENTS];
 } dleaf_t;
 
-typedef struct
-{
-	int         contents;
-	int         visofs;             // -1 = no visibility info
+typedef struct {
+	int            contents;
+	int            visofs;          // -1 = no visibility info
 
-	short       mins[3];            // for frustum culling
-	short       maxs[3];
+	short          mins[3];         // for frustum culling
+	short          maxs[3];
 
-	unsigned int    firstmarksurface;
-	unsigned int    nummarksurfaces;
+	unsigned int   firstmarksurface;
+	unsigned int   nummarksurfaces;
 
-	byte        ambient_level[NUM_AMBIENTS];
+	byte           ambient_level[NUM_AMBIENTS];
 } dleaf29a_t;
 
-typedef struct
-{
-	int         contents;
-	int         visofs;             // -1 = no visibility info
+typedef struct {
+	int            contents;
+	int            visofs;          // -1 = no visibility info
 
-	float       mins[3];            // for frustum culling
-	float       maxs[3];
+	float          mins[3];         // for frustum culling
+	float          maxs[3];
 
-	unsigned int    firstmarksurface;
-	unsigned int    nummarksurfaces;
+	unsigned int   firstmarksurface;
+	unsigned int   nummarksurfaces;
 
-	byte        ambient_level[NUM_AMBIENTS];
+	byte           ambient_level[NUM_AMBIENTS];
 } dleaf_bsp2_t;
 
 #endif /* !__BSPFILE_H__ */

--- a/src/build.c
+++ b/src/build.c
@@ -50,7 +50,9 @@ char *VersionStringFull (void)
 {
 	static char str[256];
 
-	snprintf (str, sizeof(str), SERVER_NAME " %s " "(" QW_PLATFORM ")" "\n" BUILD_DATE "\n", VersionString());
+	if (!str[0]) {
+		snprintf(str, sizeof(str), SERVER_NAME " %s " "(" QW_PLATFORM ")" "\n" BUILD_DATE "\n", VersionString());
+	}
 
 	return str;
 }

--- a/src/central.c
+++ b/src/central.c
@@ -496,13 +496,14 @@ static void Web_PostFileRequest_f(void)
 	}
 
 	if (specified[0] == '*' && specified[1] == '\0') {
-		if (!sv.mvdrecording || !demo.dest) {
+		const char* demoname = SV_MVDDemoName();
+
+		if (!sv.mvdrecording || !demoname) {
 			Con_Printf("Not recording demo!\n");
 			return;
 		}
 
-		// FIXME: dunno is this right, just using first dest, also may be we must use demo.dest->path instead of sv_demoDir
-		snprintf(path, MAX_OSPATH, "%s/%s/%s", fs_gamedir, sv_demoDir.string, SV_MVDName2Txt(demo.dest->name));
+		snprintf(path, MAX_OSPATH, "%s/%s/%s", fs_gamedir, sv_demoDir.string, SV_MVDName2Txt(demoname));
 	}
 	else {
 		if (strstr(specified, ".cfg") || !strchr(specified, '/')) {

--- a/src/central.c
+++ b/src/central.c
@@ -1,0 +1,656 @@
+
+// central.c - communication with central server
+
+#include "qwsvdef.h"
+#include <curl/curl.h>
+
+#define GENERATE_CHALLENGE_PATH     "Authentication/GenerateChallenge"
+#define VERIFY_RESPONSE_PATH        "Authentication/VerifyResponse"
+#define CHECKIN_PATH                "ServerApi/Checkin"
+#define MIN_CHECKIN_PERIOD          60
+
+#ifdef _WIN32
+#pragma comment(lib, "libcurld.lib")
+#pragma comment(lib, "ws2_32.lib")
+#pragma comment(lib, "wldap32.lib")
+#endif
+
+static cvar_t central_server_address = { "cs_address", "" };
+static cvar_t central_server_authkey = { "cs_authkey", "" };
+static cvar_t central_server_checkin_period = { "cs_checkin_period", "60" };
+
+static CURLM* curl_handle = NULL;
+
+static double last_checkin_time;
+
+#define MAX_RESPONSE_LENGTH    (4096*2)
+
+struct web_request_data_s;
+
+typedef void(*web_response_func_t)(struct web_request_data_s* req, qbool valid);
+static void Web_ConstructURL(char* url, const char* path, int sizeof_url);
+static void Web_SubmitRequestForm(const char* url, struct curl_httppost *first_form_ptr, struct curl_httppost *last_form_ptr, web_response_func_t callback, const char* requestId, void* internal_data);
+
+typedef struct web_request_data_s {
+	CURL*               handle;
+	double              time_sent;
+
+	// response from server
+	char                response[MAX_RESPONSE_LENGTH];
+	size_t              response_length;
+
+	// form data
+	struct curl_httppost *first_form_ptr;
+	struct curl_httppost *last_form_ptr;
+
+	// called when response complete
+	web_response_func_t onCompleteCallback;
+	void*               internal_data;
+	char*               request_id;                 // if set, content will be passed to game-mod. will be Q_free()'d
+
+	struct web_request_data_s* next;
+} web_request_data_t;
+
+static int utf8Encode(char in, char* out1, char* out2) {
+	if (in <= 0x7F) {
+		// <= 127 is encoded as single byte, no translation
+		*out1 = in;
+		return 1;
+	}
+	else {
+		// Two byte characters... 5 bits then 6
+		*out1 = 0xC0 | ((in >> 6) & 0x1F);
+		*out2 = 0x80 | (in & 0x3F);
+		return 2;
+	}
+}
+
+static web_request_data_t* web_requests;
+
+static qbool CheckFileExists(const char* path)
+{
+	FILE* f;
+	if (!(f = fopen(path, "rb"))) {
+		return false;
+	}
+	fclose(f);
+	return true;
+}
+
+size_t Web_StandardTokenWrite(void* buffer, size_t size, size_t nmemb, void* userp)
+{
+	web_request_data_t* data = (web_request_data_t*)userp;
+	size_t available = sizeof(data->response) - data->response_length;
+	if (size * nmemb > available) {
+		Con_DPrintf("WWW: Response too large, size*nmemb = %d, available %d\n", size * nmemb, available);
+		return 0;
+	}
+	else if (size * nmemb > 0) {
+		Con_DPrintf("WWW: response received, writing %d bytes\n", size * nmemb);
+		memcpy(data->response + data->response_length, buffer, size * nmemb);
+		data->response_length += size * nmemb;
+		Con_DPrintf("WWW: response_length now %d bytes\n", data->response_length);
+	}
+	return size * nmemb;
+}
+
+typedef struct response_field_s {
+	const char* name;
+	const char** value;
+} response_field_t;
+
+static int ProcessWebResponse(web_request_data_t* req, response_field_t* fields, int field_count)
+{
+	char* colon, *newline;
+	char* start = req->response;
+	int i;
+	int total_fields = 0;
+
+	// Response should be multiple lines, <Key>:<Value>\n
+	// For multi-line values, prefix end of line with $
+	req->response[req->response_length] = '\0';
+	while ((colon = strchr(start, ':'))) {
+		newline = strchr(colon, '\n');
+		if (newline) {
+			while (newline && newline != colon + 1 && *(newline - 1) == '$') {
+				*(newline - 1) = ' ';
+				newline = strchr(newline + 1, '\n');
+			}
+			if (newline) {
+				*newline = '\0';
+			}
+		}
+
+		*colon = '\0';
+		for (i = 0; i < field_count; ++i) {
+			if (!strcmp(start, fields[i].name)) {
+				*fields[i].value = colon + 1;
+			}
+		}
+
+		if (newline == NULL) {
+			break;
+		}
+
+		start = newline + 1;
+		while (*start && (*start == 10 || *start == 13)) {
+			++start;
+		}
+		++total_fields;
+	}
+
+	return total_fields;
+}
+
+void Auth_GenerateChallengeResponse(web_request_data_t* req, qbool valid)
+{
+	client_t* client = (client_t*) req->internal_data;
+	const char* response = NULL;
+	const char* challenge = NULL;
+	const char* message = NULL;
+	response_field_t fields[] = {
+		{ "Result", &response },
+		{ "Challenge", &challenge },
+		{ "Message", &message }
+	};
+
+	if (client->login_request_time != req->time_sent) {
+		// Ignore result, subsequent request sent
+		return;
+	}
+
+	req->internal_data = NULL;
+	ProcessWebResponse(req, fields, sizeof(fields) / sizeof(fields[0]));
+
+	if (response && !strcmp(response, "Success") && challenge) {
+		char buffer[128];
+		strlcpy(buffer, "//challenge ", sizeof(buffer));
+		strlcat(buffer, challenge, sizeof(buffer));
+		strlcat(buffer, "\n", sizeof(buffer));
+
+		strlcpy(client->challenge, challenge, sizeof(client->challenge));
+		SV_ClientPrintf(client, PRINT_HIGH, "Challenge stored...\n", message);
+
+		ClientReliableWrite_Begin (client, svc_stufftext, 2+strlen(buffer));
+		ClientReliableWrite_String (client, buffer);
+	}
+	else if (message) {
+		SV_ClientPrintf(client, PRINT_HIGH, "Error: %s\n", message);
+	}
+	else {
+		// Maybe add CURLOPT_ERRORBUFFER?
+		SV_ClientPrintf(client, PRINT_HIGH, "Error: unknown error\n");
+	}
+}
+
+void Auth_ProcessLoginAttempt(web_request_data_t* req, qbool valid)
+{
+	client_t* client = (client_t*) req->internal_data;
+	const char* response = NULL;
+	const char* login = NULL;
+	const char* preferred_alias = NULL;
+	const char* message = NULL;
+	response_field_t fields[] = {
+		{ "Result", &response },
+		{ "Alias", &preferred_alias },
+		{ "Login", &login },
+		{ "Message", &message }
+	};
+
+	req->internal_data = NULL;
+	if (client->login_request_time != req->time_sent) {
+		// Ignore result, subsequent request sent
+		return;
+	}
+
+	ProcessWebResponse(req, fields, sizeof(fields) / sizeof(fields[0]));
+
+	if (response && !strcmp(response, "Success")) {
+		if (login) {
+			char oldval[MAX_EXT_INFO_STRING];
+
+			strlcpy(oldval, Info_Get(&client->_userinfo_ctx_, "*auth"), sizeof(oldval));
+			strlcpy(client->login, login, sizeof(client->login));
+
+			Info_SetStar(&client->_userinfo_ctx_, "*auth", login);
+			ProcessUserInfoChange(client, "*auth", oldval);
+		}
+
+		if (!preferred_alias) {
+			preferred_alias = login;
+		}
+
+		if (preferred_alias) {
+			char oldval[MAX_EXT_INFO_STRING];
+			strlcpy (oldval, client->name, MAX_EXT_INFO_STRING);
+
+			// Change nickname
+			SV_BroadcastPrintf(PRINT_HIGH, "%s logged in as %s\n", client->name, preferred_alias);
+			Info_Set(&client->_userinfo_ctx_, "name", preferred_alias);
+
+			ProcessUserInfoChange(client, "name", oldval);
+
+			if (strcmp(preferred_alias, oldval)) {
+				// Change name cvar in client
+				MSG_WriteByte (&client->netchan.message, svc_stufftext);
+				MSG_WriteString (&client->netchan.message, va("name %s\n", preferred_alias));
+			}
+		}
+		client->logged = true;
+	}
+	else if (message) {
+		SV_ClientPrintf(client, PRINT_HIGH, "Error: %s\n", message);
+	}
+	else {
+		// Maybe add CURLOPT_ERRORBUFFER?
+		SV_ClientPrintf(client, PRINT_HIGH, "Error: unknown error\n");
+	}
+}
+
+void Web_PostResponse(web_request_data_t* req, qbool valid)
+{
+	if (valid) {
+		const char* broadcast = NULL;
+		const char* upload = NULL;
+		const char* uploadPath = NULL;
+
+		response_field_t fields[] = {
+			{ "Broadcast", &broadcast },
+			{ "UploadPath", &uploadPath },
+			{ "Upload", &upload }
+		};
+
+		req->response[req->response_length] = '\0';
+
+		Con_DPrintf("Response from web server:\n");
+		Con_DPrintf(req->response);
+
+		ProcessWebResponse(req, fields, sizeof(fields) / sizeof(fields[0]));
+
+		if (broadcast) {
+			// Server is making announcement
+			SV_BroadcastPrintfEx(PRINT_HIGH, 0, "%s\n", broadcast);
+		}
+		if (upload && uploadPath) {
+			if (strstr(uploadPath, "//") || FS_UnsafeFilename(upload)) {
+				Con_Printf("Upload request deemed unsafe, ignoring...\n");
+			}
+			else {
+				if (!strncmp(upload, "demos/", 6)) {
+					// Ok - could be demo_dir, or full path
+					char demoName[MAX_OSPATH];
+
+					if (sv_demoDir.string[0]) {
+						char url[512];
+						struct curl_httppost *first_form_ptr = NULL;
+						struct curl_httppost *last_form_ptr = NULL;
+
+						snprintf(demoName, sizeof(demoName), "%s/%s/%s", fs_gamedir, sv_demoDir.string, upload + 6);
+
+						if (CheckFileExists(demoName)) {
+							Web_ConstructURL(url, uploadPath, sizeof(url));
+
+							curl_formadd(&first_form_ptr, &last_form_ptr,
+								CURLFORM_PTRNAME, "file",
+								CURLFORM_FILE, demoName,
+								CURLFORM_END
+							);
+
+							curl_formadd(&first_form_ptr, &last_form_ptr,
+								CURLFORM_COPYNAME, "localPath",
+								CURLFORM_COPYCONTENTS, upload,
+								CURLFORM_END
+							);
+
+							Web_SubmitRequestForm(url, first_form_ptr, last_form_ptr, Web_PostResponse, "upload", NULL);
+							Con_Printf("Uploading %s...\n", demoName);
+						}
+						else {
+							Con_Printf("Couldn't find file %s, ignoring...\n", demoName);
+						}
+					}
+				}
+				else {
+					Con_Printf("Upload request folder not authorised, ignoring...\n");
+				}
+			}
+		}
+	}
+	else {
+		Con_Printf("Failure contacting central server.\n");
+	}
+
+	if (req->internal_data) {
+		Q_free(req->internal_data);
+	}
+}
+
+static void Web_SubmitRequestForm(const char* url, struct curl_httppost *first_form_ptr, struct curl_httppost *last_form_ptr, web_response_func_t callback, const char* requestId, void* internal_data)
+{
+	CURL* req = curl_easy_init();
+	web_request_data_t* data = Q_malloc(sizeof(web_request_data_t));
+	CURLFORMcode code = curl_formadd(&first_form_ptr, &last_form_ptr,
+		CURLFORM_PTRNAME, "authKey",
+		CURLFORM_COPYCONTENTS, central_server_authkey.string,
+		CURLFORM_END
+	);
+
+	data->onCompleteCallback = callback;
+	data->time_sent = sv.time;
+	data->internal_data = internal_data;
+	data->handle = req;
+	data->request_id = requestId && requestId[0] ? strdup(requestId) : NULL;
+	data->first_form_ptr = first_form_ptr;
+
+	curl_easy_setopt(req, CURLOPT_URL, url);
+	curl_easy_setopt(req, CURLOPT_WRITEDATA, data);
+	curl_easy_setopt(req, CURLOPT_WRITEFUNCTION, Web_StandardTokenWrite);
+	if (first_form_ptr) {
+		curl_easy_setopt(req, CURLOPT_POST, 1);
+		curl_easy_setopt(req, CURLOPT_HTTPPOST, first_form_ptr);
+	}
+
+	curl_multi_add_handle(curl_handle, req);
+	data->next = web_requests;
+	web_requests = data;
+}
+
+void Central_VerifyChallengeResponse(client_t* client, const char* challenge, const char* response)
+{
+	char url[512];
+	struct curl_httppost *first_form_ptr = NULL;
+	struct curl_httppost *last_form_ptr = NULL;
+	CURLFORMcode code;
+
+	code = curl_formadd(&first_form_ptr, &last_form_ptr,
+		CURLFORM_PTRNAME, "challenge",
+		CURLFORM_COPYCONTENTS, challenge,
+		CURLFORM_END
+	);
+
+	code = curl_formadd(&first_form_ptr, &last_form_ptr,
+		CURLFORM_PTRNAME, "response",
+		CURLFORM_COPYCONTENTS, response,
+		CURLFORM_END
+	);
+
+	Web_ConstructURL(url, VERIFY_RESPONSE_PATH, sizeof(url));
+
+	client->login_request_time = sv.time;
+	Web_SubmitRequestForm(url, first_form_ptr, last_form_ptr, Auth_ProcessLoginAttempt, NULL, client);
+}
+
+void Central_GenerateChallenge(client_t* client, const char* username)
+{
+	char url[512];
+	struct curl_httppost *first_form_ptr = NULL;
+	struct curl_httppost *last_form_ptr = NULL;
+	CURLFORMcode code;
+
+	Web_ConstructURL(url, GENERATE_CHALLENGE_PATH, sizeof(url));
+
+	code = curl_formadd(&first_form_ptr, &last_form_ptr,
+		CURLFORM_PTRNAME, "userName",
+		CURLFORM_COPYCONTENTS, username,
+		CURLFORM_END
+	);
+
+	client->login_request_time = sv.time;
+	Web_SubmitRequestForm(url, first_form_ptr, last_form_ptr, Auth_GenerateChallengeResponse, NULL, client);
+}
+
+static void Web_ConstructURL(char* url, const char* path, int sizeof_url)
+{
+	strlcpy(url, central_server_address.string, sizeof_url);
+	if (url[strlen(url) - 1] != '/') {
+		strlcat(url, "/", sizeof_url);
+	}
+	while (*path == '/') {
+		++path;
+	}
+	strlcat(url, path, sizeof_url);
+}
+
+static void Web_SendRequest(qbool post)
+{
+	struct curl_httppost *first_form_ptr = NULL;
+	struct curl_httppost *last_form_ptr = NULL;
+	char url[512];
+	char* requestId = NULL;
+	int i;
+
+	if (!central_server_address.string[0]) {
+		Con_Printf("Address not set - functionality disabled\n");
+		return;
+	}
+
+	if (Cmd_Argc() < 3) {
+		Con_Printf("Usage: %s <url> <request-id> (<key> <value>)*\n", Cmd_Argv(0));
+		return;
+	}
+
+	Web_ConstructURL(url, Cmd_Argv(1), sizeof(url));
+
+	requestId = Cmd_Argv(2);
+	if (requestId[0]) {
+		requestId = Q_strdup(requestId);
+	}
+	else {
+		requestId = NULL;
+	}
+
+	for (i = 3; i < Cmd_Argc() - 1; i += 2) {
+		char encoded_value[128];
+		int encoded_length = 0;
+		int j;
+		char* name;
+		char* value;
+		CURLFORMcode code;
+
+		name = Cmd_Argv(i);
+		value = Cmd_Argv(i + 1);
+		for (j = 0; j < strlen(value) && encoded_length < sizeof(encoded_value) - 2; ++j) {
+			encoded_length += utf8Encode(value[j], &encoded_value[encoded_length], &encoded_value[encoded_length + 1]);
+		}
+		encoded_value[encoded_length] = '\0';
+
+		code = curl_formadd(&first_form_ptr, &last_form_ptr,
+			CURLFORM_COPYNAME, name,
+			CURLFORM_COPYCONTENTS, encoded_value,
+			CURLFORM_END
+		);
+
+		if (code != CURLE_OK) {
+			curl_formfree(first_form_ptr);
+			Con_Printf("Request failed\n");
+			return;
+		}
+	}
+
+	Web_SubmitRequestForm(url, first_form_ptr, last_form_ptr, Web_PostResponse, requestId, NULL);
+}
+
+static void Web_GetRequest_f(void)
+{
+	Web_SendRequest(false);
+}
+
+static void Web_PostRequest_f(void)
+{
+	Web_SendRequest(true);
+}
+
+static void Web_PostFileRequest_f(void)
+{
+	struct curl_httppost *first_form_ptr = NULL;
+	struct curl_httppost *last_form_ptr = NULL;
+	char* requestId = NULL;
+	char url[512];
+	char path[MAX_OSPATH];
+	CURLFORMcode code = 0;
+	const char* specified = Cmd_Argv(3);
+
+	if (!central_server_address.string[0]) {
+		Con_Printf("Address not set - functionality disabled\n");
+		return;
+	}
+
+	if (specified[0] == '*' && specified[1] == '\0') {
+		if (!sv.mvdrecording || !demo.dest) {
+			Con_Printf("Not recording demo!\n");
+			return;
+		}
+
+		// FIXME: dunno is this right, just using first dest, also may be we must use demo.dest->path instead of sv_demoDir
+		snprintf(path, MAX_OSPATH, "%s/%s/%s", fs_gamedir, sv_demoDir.string, SV_MVDName2Txt(demo.dest->name));
+	}
+	else {
+		if (strstr(specified, ".cfg") || !strchr(specified, '/')) {
+			Con_Printf("Filename invalid\n");
+			return;
+		}
+
+		snprintf(path, MAX_OSPATH, "%s/%s", fs_gamedir, specified);
+	}
+
+	if (Cmd_Argc() < 4) {
+		Con_Printf("Usage: %s <url> <request-id> <file> (<key> <value>)*\n", Cmd_Argv(0));
+		return;
+	}
+
+	if (FS_UnsafeFilename(path)) {
+		Con_Printf("Filename invalid\n");
+		return;
+	}
+
+	Web_ConstructURL(url, Cmd_Argv(1), sizeof(url));
+
+	requestId = Cmd_Argv(2);
+	if (requestId[0]) {
+		requestId = Q_strdup(requestId);
+	}
+	else {
+		requestId = NULL;
+	}
+
+	if (! CheckFileExists(path)) {
+		Con_Printf("Failed to open file\n");
+		return;
+	}
+
+	code = curl_formadd(&first_form_ptr, &last_form_ptr,
+		CURLFORM_PTRNAME, "file",
+		CURLFORM_FILE, path,
+		CURLFORM_END
+	);
+
+	Web_SubmitRequestForm(url, first_form_ptr, last_form_ptr, Web_PostResponse, requestId, NULL);
+}
+
+void Central_ProcessResponses(void)
+{
+	CURLMsg* msg;
+	int running_handles = 0;
+	int messages_in_queue = 0;
+	qbool server_busy = false;
+
+	if (!last_checkin_time) {
+		last_checkin_time = curtime;
+		return;
+	}
+
+	curl_multi_perform(curl_handle, &running_handles);
+
+	server_busy = running_handles || GameStarted();
+
+	while ((msg = curl_multi_info_read(curl_handle, &messages_in_queue))) {
+		if (msg->msg == CURLMSG_DONE) {
+			CURL* handle = msg->easy_handle;
+			CURLcode result = msg->data.result;
+			web_request_data_t** list_pointer = &web_requests;
+
+			curl_multi_remove_handle(curl_handle, handle);
+
+			while (*list_pointer) {
+				web_request_data_t* this = *list_pointer;
+
+				if (this->handle == handle) {
+					// Remove from queue immediately
+					*list_pointer = this->next;
+
+					if (this->request_id && !strcmp(this->request_id, "upload")) {
+						this = this;
+					}
+					if (this->onCompleteCallback) {
+						if (result == CURLE_OK) {
+							this->onCompleteCallback(this, true);
+						}
+						else {
+							Con_DPrintf("ERROR: %s\n", curl_easy_strerror(result));
+							this->onCompleteCallback(this, false);
+						}
+					}
+					else {
+						if (result != CURLE_OK) {
+							Con_DPrintf("ERROR: %s\n", curl_easy_strerror(result));
+						}
+						else {
+							Con_DPrintf("WEB OK, no callback\n");
+						}
+					}
+
+					// free memory
+					curl_formfree(this->first_form_ptr);
+					Q_free(this->request_id);
+					Q_free(this);
+
+					break;
+				}
+
+				list_pointer = &this->next;
+			}
+
+			curl_easy_cleanup(handle);
+		}
+	}
+
+	if (central_server_address.string[0] && !server_busy && curtime - last_checkin_time > max(MIN_CHECKIN_PERIOD, central_server_checkin_period.value)) {
+		char url[512];
+
+		Web_ConstructURL(url, CHECKIN_PATH, sizeof(url));
+
+		Web_SubmitRequestForm(url, NULL, NULL, Web_PostResponse, NULL, NULL);
+
+		last_checkin_time = curtime;
+	}
+	else if (server_busy) {
+		last_checkin_time = curtime;
+	}
+}
+
+void Central_Shutdown(void)
+{
+	if (curl_handle) {
+		curl_multi_cleanup(curl_handle);
+		curl_handle = NULL;
+	}
+
+	curl_global_cleanup();
+}
+
+void Central_Init(void)
+{
+	curl_global_init(CURL_GLOBAL_DEFAULT);
+
+	Cvar_Register(&central_server_address);
+	Cvar_Register(&central_server_authkey);
+	Cvar_Register(&central_server_checkin_period);
+
+	curl_handle = curl_multi_init();
+
+	if (curl_handle) {
+		Cmd_AddCommand("sv_web_get", Web_GetRequest_f);
+		Cmd_AddCommand("sv_web_post", Web_PostRequest_f);
+		Cmd_AddCommand("sv_web_postfile", Web_PostFileRequest_f);
+	}
+}

--- a/src/central.h
+++ b/src/central.h
@@ -1,0 +1,10 @@
+
+#ifndef CENTRAL_H
+#define CENTRAL_H
+
+void Central_Init(void);
+void Central_Shutdown(void);
+void Central_ProcessResponses(void);
+void Central_SubmitGame(const char* path);
+
+#endif // !CENTRAL_H

--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -57,7 +57,7 @@ static int			numplanes;
 static cnode_t		*map_nodes;
 static int			numnodes;
 
-static dclipnode_t	*map_clipnodes;
+static mclipnode_t	*map_clipnodes;
 static int			numclipnodes;
 
 static cleaf_t		*map_leafs;
@@ -87,7 +87,7 @@ HULL BOXES
 */
 
 static hull_t		box_hull;
-static dclipnode_t	box_clipnodes[6];
+static mclipnode_t	box_clipnodes[6];
 static mplane_t		box_planes[6];
 
 /*
@@ -138,7 +138,7 @@ hull_t *CM_HullForBox (vec3_t mins, vec3_t maxs)
 
 int CM_HullPointContents (hull_t *hull, int num, vec3_t p)
 {
-	dclipnode_t *node;
+	mclipnode_t *node;
 	mplane_t *plane;
 	float d;
 
@@ -187,7 +187,7 @@ int RecursiveHullTrace (hulltrace_local_t *htl, int num, float p1f, float p2f, c
 {
 	mplane_t	*plane;
 	float		t1, t2;
-	dclipnode_t *node;
+	mclipnode_t *node;
 	int			i;
 	int			nearside;
 	float		frac, midf;
@@ -399,6 +399,10 @@ byte *CM_LeafPHS (const cleaf_t *leaf)
 	if (leaf == map_leafs)
 		return map_novis;
 
+	if (!map_phs) {
+		return NULL;
+	}
+
 	return map_phs + (leaf - 1 - map_leafs) * map_vis_rowbytes;
 }
 
@@ -475,6 +479,7 @@ byte *CM_FatPVS (vec3_t org)
 */
 static int leafs_count;
 static int leafs_maxcount;
+static qbool leafs_overflow;
 static int *leafs_list;
 static int leafs_topnode;
 static vec3_t leafs_mins, leafs_maxs;
@@ -493,8 +498,10 @@ static void FindTouchedLeafs_r (const cnode_t *node)
 		// the node is a leaf
 		if (node->contents < 0)
 		{
-			if (leafs_count == leafs_maxcount)
+			if (leafs_count == leafs_maxcount) {
+				leafs_overflow = true;
 				return;
+			}
 
 			leaf = (cleaf_t *)node;
 			leafs_list[leafs_count++] = leaf - map_leafs;
@@ -506,14 +513,17 @@ static void FindTouchedLeafs_r (const cnode_t *node)
 		sides = BOX_ON_PLANE_SIDE (leafs_mins, leafs_maxs, splitplane);
 
 		// recurse down the contacted sides
-		if (sides == 1)
+		if (sides == 1) {
 			node = node->children[0];
-		else if (sides == 2)
+		}
+		else if (sides == 2) {
 			node = node->children[1];
+		}
 		else
 		{
-			if (leafs_topnode == -1)
+			if (leafs_topnode == -1) {
 				leafs_topnode = node - map_nodes;
+			}
 			FindTouchedLeafs_r (node->children[0]);
 			node = node->children[1];
 		}
@@ -529,10 +539,15 @@ int CM_FindTouchedLeafs (const vec3_t mins, const vec3_t maxs, int leafs[], int 
 	leafs_maxcount = maxleafs;
 	leafs_list = leafs;
 	leafs_topnode = -1;
+	leafs_overflow = false;
 	VectorCopy (mins, leafs_mins);
 	VectorCopy (maxs, leafs_maxs);
 
 	FindTouchedLeafs_r (&map_nodes[headnode]);
+
+	if (leafs_overflow) {
+		leafs_count = -1;
+	}
 
 	if (topnode)
 		*topnode = leafs_topnode;
@@ -582,7 +597,7 @@ static void CM_LoadSubmodels (lump_t *l)
 		Host_Error ("Map with no models");
 
 	if (count > MAX_MAP_MODELS)
-		Host_Error ("Map has too many models");
+		Host_Error ("Map has too many models (%d vs %d)", count, MAX_MAP_MODELS);
 
 	out = map_cmodels;
 	numcmodels = count;
@@ -679,6 +694,68 @@ static void CM_LoadNodes (lump_t *l)
 	CM_SetParent (map_nodes, NULL); // sets nodes and leafs
 }
 
+static void CM_LoadNodes29a (lump_t *l)
+{
+	int i, j, count, p;
+	dnode29a_t *in;
+	cnode_t *out;
+
+	in = (dnode29a_t *)(cmod_base + l->fileofs);
+	if (l->filelen % sizeof(*in))
+		Host_Error ("CM_LoadMap: funny lump size");
+
+	count = l->filelen / sizeof(*in);
+	out = Hunk_AllocName ( count*sizeof(*out), loadname);
+
+	map_nodes = out;
+	numnodes = count;
+
+	for (i = 0; i < count; i++, in++, out++)
+	{
+		p = LittleLong(in->planenum);
+		out->plane = map_planes + p;
+
+		for (j=0 ; j<2 ; j++)
+		{
+			p = LittleLong (in->children[j]);
+			out->children[j] = (p >= 0) ? (map_nodes + p) : ((cnode_t *)(map_leafs + (-1 - p)));
+		}
+	}
+
+	CM_SetParent (map_nodes, NULL); // sets nodes and leafs
+}
+
+static void CM_LoadNodesBSP2 (lump_t *l)
+{
+	int i, j, count, p;
+	dnode_bsp2_t *in;
+	cnode_t *out;
+
+	in = (dnode_bsp2_t *)(cmod_base + l->fileofs);
+	if (l->filelen % sizeof(*in))
+		Host_Error ("CM_LoadMap: funny lump size");
+
+	count = l->filelen / sizeof(*in);
+	out = Hunk_AllocName ( count*sizeof(*out), loadname);
+
+	map_nodes = out;
+	numnodes = count;
+
+	for (i = 0; i < count; i++, in++, out++)
+	{
+		p = LittleLong(in->planenum);
+		out->plane = map_planes + p;
+
+		for (j=0 ; j<2 ; j++)
+		{
+			p = LittleLong (in->children[j]);
+			out->children[j] = (p >= 0) ? (map_nodes + p) : ((cnode_t *)(map_leafs + (-1 - p)));
+		}
+	}
+
+	CM_SetParent (map_nodes, NULL); // sets nodes and leafs
+}
+
 /*
 ** CM_LoadLeafs
 */
@@ -705,7 +782,62 @@ static void CM_LoadLeafs (lump_t *l)
 		for (j = 0; j < 4; j++)
 			out->ambient_sound_level[j] = in->ambient_level[j];
 	}
+}
 
+
+static void CM_LoadLeafs29a (lump_t *l)
+{
+	dleaf29a_t *in;
+
+	cleaf_t *out;
+	int i, j, count, p;
+
+	in = (dleaf29a_t *)(cmod_base + l->fileofs);
+
+	if (l->filelen % sizeof(*in)) {
+		Host_Error("CM_LoadMap: funny lump size");
+	}
+
+	count = l->filelen / sizeof(*in);
+	out = Hunk_AllocName ( count*sizeof(*out), loadname);
+
+	map_leafs = out;
+	numleafs = count;
+
+	for (i = 0; i < count; i++, in++, out++) {
+		p = LittleLong(in->contents);
+		out->contents = p;
+		for (j = 0; j < 4; j++)
+			out->ambient_sound_level[j] = in->ambient_level[j];
+	}
+
+}
+
+static void CM_LoadLeafsBSP2 (lump_t *l)
+{
+	dleaf_bsp2_t *in;
+
+	cleaf_t *out;
+	int i, j, count, p;
+
+	in = (dleaf_bsp2_t *)(cmod_base + l->fileofs);
+
+	if (l->filelen % sizeof(*in)) {
+		Host_Error("CM_LoadMap: funny lump size");
+	}
+
+	count = l->filelen / sizeof(*in);
+	out = Hunk_AllocName ( count*sizeof(*out), loadname);
+
+	map_leafs = out;
+	numleafs = count;
+
+	for (i = 0; i < count; i++, in++, out++) {
+		p = LittleLong(in->contents);
+		out->contents = p;
+		for (j = 0; j < 4; j++)
+			out->ambient_sound_level[j] = in->ambient_level[j];
+	}
 }
 
 /*
@@ -715,7 +847,8 @@ CM_LoadClipnodes
 */
 static void CM_LoadClipnodes (lump_t *l)
 {
-	dclipnode_t *in, *out;
+	dclipnode_t *in;
+	mclipnode_t *out;
 	int i, count;
 
 	in = (dclipnode_t *) (cmod_base + l->fileofs);
@@ -724,7 +857,7 @@ static void CM_LoadClipnodes (lump_t *l)
 		Host_Error ("CM_LoadMap: funny lump size");
 
 	count = l->filelen / sizeof(*in);
-	out = (dclipnode_t *) Hunk_AllocName ( count*sizeof(*out), loadname);
+	out = (mclipnode_t *) Hunk_AllocName ( count*sizeof(*out), loadname);
 
 	map_clipnodes = out;
 	numclipnodes = count;
@@ -734,6 +867,29 @@ static void CM_LoadClipnodes (lump_t *l)
 		out->planenum = LittleLong(in->planenum);
 		out->children[0] = LittleShort(in->children[0]);
 		out->children[1] = LittleShort(in->children[1]);
+	}
+}
+
+static void CM_LoadClipnodesBSP2 (lump_t *l)
+{
+	dclipnode29a_t *in;
+	mclipnode_t *out;
+	int i, count;
+
+	in = (void *)(cmod_base + l->fileofs);
+	if (l->filelen % sizeof(*in))
+		Host_Error ("CM_LoadMap: funny lump size");
+	count = l->filelen / sizeof(*in);
+	out = Hunk_AllocName ( count*sizeof(*out), loadname);
+
+	map_clipnodes = out;
+	numclipnodes = count;
+
+	for (i = 0; i < count; i++, out++, in++)
+	{
+		out->planenum = LittleLong(in->planenum);
+		out->children[0] = LittleLong(in->children[0]);
+		out->children[1] = LittleLong(in->children[1]);
 	}
 }
 
@@ -747,12 +903,12 @@ Deplicate the drawing hull structure as a clipping hull
 static void CM_MakeHull0 (void)
 {
 	cnode_t *in, *child;
-	dclipnode_t *out;
+	mclipnode_t *out;
 	int i, j, count;
 
 	in = map_nodes;
 	count = numnodes;
-	out = (dclipnode_t *) Hunk_AllocName (count*sizeof(*out), loadname);
+	out = (mclipnode_t *) Hunk_AllocName (count*sizeof(*out), loadname);
 
 	// fix up hull 0 in all cmodels
 	for (i = 0; i < numcmodels; i++) {
@@ -771,6 +927,7 @@ static void CM_MakeHull0 (void)
 		}
 	}
 }
+
 
 /*
 =================
@@ -889,6 +1046,66 @@ static void CM_BuildPVS (lump_t *lump_vis, lump_t *lump_leafs)
 	}
 }
 
+static void CM_BuildPVS29a (lump_t *lump_vis, lump_t *lump_leafs)
+{
+	byte *visdata, *scan;
+	dleaf29a_t *in;
+	int i;
+
+	map_vis_rowlongs = (visleafs + 31) >> 5;
+	map_vis_rowbytes = map_vis_rowlongs * 4;
+	map_pvs = Hunk_Alloc (map_vis_rowbytes * visleafs);
+
+	if (!lump_vis->filelen) {
+		memset (map_pvs, 0xff, map_vis_rowbytes * visleafs);
+		return;
+	}
+
+	// FIXME, add checks for lump_vis->filelen and leafs' visofs
+
+	visdata = cmod_base + lump_vis->fileofs;
+
+	// go through all leafs and decompress visibility data
+	in = (dleaf29a_t *)(cmod_base + lump_leafs->fileofs);
+	in++; // pvs row 0 is leaf 1
+	scan = map_pvs;
+	for (i = 0; i < visleafs; i++, in++, scan += map_vis_rowbytes)
+	{
+		int p = LittleLong(in->visofs);
+		memcpy (scan, (p == -1) ? map_novis : DecompressVis (visdata + p), map_vis_rowbytes);
+	}
+}
+
+static void CM_BuildPVSBSP2 (lump_t *lump_vis, lump_t *lump_leafs)
+{
+	byte *visdata, *scan;
+	dleaf_bsp2_t *in;
+	int i;
+
+	map_vis_rowlongs = (visleafs + 31) >> 5;
+	map_vis_rowbytes = map_vis_rowlongs * 4;
+	map_pvs = Hunk_Alloc (map_vis_rowbytes * visleafs);
+
+	if (!lump_vis->filelen) {
+		memset (map_pvs, 0xff, map_vis_rowbytes * visleafs);
+		return;
+	}
+
+	// FIXME, add checks for lump_vis->filelen and leafs' visofs
+
+	visdata = cmod_base + lump_vis->fileofs;
+
+	// go through all leafs and decompress visibility data
+	in = (dleaf_bsp2_t *)(cmod_base + lump_leafs->fileofs);
+	in++; // pvs row 0 is leaf 1
+	scan = map_pvs;
+	for (i = 0; i < visleafs; i++, in++, scan += map_vis_rowbytes)
+	{
+		int p = LittleLong(in->visofs);
+		memcpy (scan, (p == -1) ? map_novis : DecompressVis (visdata + p), map_vis_rowbytes);
+	}
+}
+
 
 /*
 ** CM_BuildPHS
@@ -901,6 +1118,11 @@ static void CM_BuildPHS (void)
 	int i, j, k, l, index1, bitbyte;
 	unsigned *dest, *src;
 	byte *scan;
+
+	map_phs = NULL;
+	if (map_vis_rowbytes * visleafs > 0x100000) {
+		return;
+	}
 
 	map_phs = (byte *) Hunk_Alloc (map_vis_rowbytes * visleafs);
 	scan = map_pvs;
@@ -955,11 +1177,15 @@ void CM_InvalidateMap (void)
 ** CM_LoadMap
 */
 extern cvar_t sv_halflifebsp;
+typedef void(*BuildPVSFunction)(lump_t *lump_vis, lump_t *lump_leafs);
 cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned *checksum2)
 {
+	extern cvar_t sv_bspversion;
+
 	unsigned int i;
 	dheader_t *header;
 	unsigned int *buf;
+	BuildPVSFunction cm_load_pvs_func = CM_BuildPVS;
 
 	if (map_name[0]) {
 		assert(!strcmp(name, map_name));
@@ -980,12 +1206,13 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 	header = (dheader_t *)buf;
 
 	i = LittleLong (header->version);
-	if (i != Q1_BSPVERSION && i != HL_BSPVERSION)
+	if (i != Q1_BSPVERSION && i != HL_BSPVERSION && i != Q1_BSPVERSION2 && i != Q1_BSPVERSION29a)
 		Host_Error ("CM_LoadMap: %s has wrong version number (%i should be %i)", name, i, Q1_BSPVERSION);
 
 	map_halflife = (i == HL_BSPVERSION);
 
 	Cvar_SetROM(&sv_halflifebsp, map_halflife ? "1" : "0");
+	Cvar_SetROM(&sv_bspversion, i == Q1_BSPVERSION || i == HL_BSPVERSION ? "1" : "2");
 
 	// swap all the lumps
 	cmod_base = (byte *)header;
@@ -1010,15 +1237,30 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 
 	// load into heap
 	CM_LoadPlanes (&header->lumps[LUMP_PLANES]);
-	CM_LoadLeafs (&header->lumps[LUMP_LEAFS]);
-	CM_LoadNodes (&header->lumps[LUMP_NODES]);
-	CM_LoadClipnodes (&header->lumps[LUMP_CLIPNODES]);
+	if (LittleLong(header->version) == Q1_BSPVERSION29a) {
+		CM_LoadLeafs29a(&header->lumps[LUMP_LEAFS]);
+		CM_LoadNodes29a(&header->lumps[LUMP_NODES]);
+		CM_LoadClipnodesBSP2(&header->lumps[LUMP_CLIPNODES]);
+		cm_load_pvs_func = CM_BuildPVS29a;
+	}
+	else if (LittleLong(header->version) == Q1_BSPVERSION2) {
+		CM_LoadLeafsBSP2(&header->lumps[LUMP_LEAFS]);
+		CM_LoadNodesBSP2(&header->lumps[LUMP_NODES]);
+		CM_LoadClipnodesBSP2(&header->lumps[LUMP_CLIPNODES]);
+		cm_load_pvs_func = CM_BuildPVSBSP2;
+	}
+	else {
+		CM_LoadLeafs(&header->lumps[LUMP_LEAFS]);
+		CM_LoadNodes(&header->lumps[LUMP_NODES]);
+		CM_LoadClipnodes(&header->lumps[LUMP_CLIPNODES]);
+		cm_load_pvs_func = CM_BuildPVS;
+	}
 	CM_LoadEntities (&header->lumps[LUMP_ENTITIES]);
 	CM_LoadSubmodels (&header->lumps[LUMP_MODELS]);
 
 	CM_MakeHull0 ();
 
-	CM_BuildPVS (&header->lumps[LUMP_VISIBILITY], &header->lumps[LUMP_LEAFS]);
+	cm_load_pvs_func (&header->lumps[LUMP_VISIBILITY], &header->lumps[LUMP_LEAFS]);
 
 	if (!clientload) // client doesn't need PHS
 		CM_BuildPHS ();

--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -17,31 +17,31 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // cmodel.c - collision model.
 
+#ifdef SERVERONLY
 #include "qwsvdef.h"
+#else
+#include "common.h"
+#include "cvar.h"
+#endif
 
-typedef struct cnode_s
-{
+typedef struct cnode_s {
 	// common with leaf
-	int				contents; // 0, to differentiate from leafs
-	struct cnode_s	*parent;
+	int                contents; // 0, to differentiate from leafs
+	struct cnode_s     *parent;
 
 	// node specific
-	mplane_t		*plane;
-	struct cnode_s	*children[2];
+	mplane_t           *plane;
+	struct cnode_s     *children[2];	
 } cnode_t;
 
-
-typedef struct cleaf_s
-{
+typedef struct cleaf_s {
 	// common with node
-	int				contents; // a negative contents number
-	struct cnode_s	*parent;
+	int                contents;         // a negative contents number
+	struct cnode_s     *parent;
 
 	// leaf specific
-	byte			ambient_sound_level[NUM_AMBIENTS];
+	byte               ambient_sound_level[NUM_AMBIENTS];
 } cleaf_t;
-
-
 
 static char			loadname[32];	// for hunk tags
 
@@ -96,7 +96,7 @@ static mplane_t		box_planes[6];
 ** Set up the planes and clipnodes so that the six floats of a bounding box
 ** can just be stored out and get a proper hull_t structure.
 */
-static void CM_InitBoxHull (void)
+static void CM_InitBoxHull(void)
 {
 	int side, i;
 
@@ -105,16 +105,13 @@ static void CM_InitBoxHull (void)
 	box_hull.firstclipnode = 0;
 	box_hull.lastclipnode = 5;
 
-	for (i = 0; i < 6; i++)
-	{
+	for (i = 0; i < 6; i++) {
 		box_clipnodes[i].planenum = i;
-
-		side = i&1;
-
+		side = i & 1;
 		box_clipnodes[i].children[side] = CONTENTS_EMPTY;
-		box_clipnodes[i].children[side^1] = (i != 5) ? (i + 1) : CONTENTS_SOLID;
-		box_planes[i].type = i>>1;
-		box_planes[i].normal[i>>1] = 1;
+		box_clipnodes[i].children[side ^ 1] = (i != 5) ? (i + 1) : CONTENTS_SOLID;
+		box_planes[i].type = i >> 1;
+		box_planes[i].normal[i >> 1] = 1;
 	}
 }
 
@@ -136,31 +133,29 @@ hull_t *CM_HullForBox (vec3_t mins, vec3_t maxs)
 	return &box_hull;
 }
 
-int CM_HullPointContents (hull_t *hull, int num, vec3_t p)
+int CM_HullPointContents(hull_t *hull, int num, vec3_t p)
 {
 	mclipnode_t *node;
 	mplane_t *plane;
 	float d;
 
-	while (num >= 0)
-	{
-		if (num < hull->firstclipnode || num > hull->lastclipnode)
-		{
-			if (map_halflife && num == hull->lastclipnode + 1)
+	while (num >= 0) {
+		if (num < hull->firstclipnode || num > hull->lastclipnode) {
+			if (map_halflife && num == hull->lastclipnode + 1) {
 				return CONTENTS_EMPTY;
-			Sys_Error ("CM_HullPointContents: bad node number");
+			}
+			Sys_Error("CM_HullPointContents: bad node number");
 		}
 
 		node = hull->clipnodes + num;
 		plane = hull->planes + node->planenum;
 
-		d = PlaneDiff (p, plane);
+		d = PlaneDiff(p, plane);
 		num = (d < 0) ? node->children[1] : node->children[0];
 	}
 
 	return num;
 }
-
 
 /*
 ===============================================================================
@@ -180,7 +175,6 @@ typedef struct {
 	trace_t	trace;
 	int leafcount;
 } hulltrace_local_t;
-
 
 //====================
 int RecursiveHullTrace (hulltrace_local_t *htl, int num, float p1f, float p2f, const vec3_t p1, const vec3_t p2)
@@ -332,7 +326,6 @@ trace_t CM_HullTrace (hull_t *hull, vec3_t start, vec3_t end)
 
 //===========================================================================
 
-
 int	CM_NumInlineModels (void)
 {
 	return numcmodels;
@@ -368,13 +361,13 @@ cleaf_t *CM_PointInLeaf (const vec3_t p)
 		Host_Error ("CM_PointInLeaf: numnodes == 0");
 
 	node = map_nodes;
-	while (1)
-	{
-		if (node->contents < 0)
+	while (1) {
+		if (node->contents < 0) {
 			return (cleaf_t *)node;
+		}
 
 		plane = node->plane;
-		d = DotProduct (p,plane->normal) - plane->dist;
+		d = DotProduct(p, plane->normal) - plane->dist;
 		node = (d > 0) ? node->children[0] : node->children[1];
 	}
 
@@ -484,20 +477,19 @@ static int *leafs_list;
 static int leafs_topnode;
 static vec3_t leafs_mins, leafs_maxs;
 
-static void FindTouchedLeafs_r (const cnode_t *node)
+static void FindTouchedLeafs_r(const cnode_t *node)
 {
 	mplane_t *splitplane;
 	cleaf_t *leaf;
 	int sides;
 
-	while (1)
-	{
-		if (node->contents == CONTENTS_SOLID)
+	while (1) {
+		if (node->contents == CONTENTS_SOLID) {
 			return;
+		}
 
 		// the node is a leaf
-		if (node->contents < 0)
-		{
+		if (node->contents < 0) {
 			if (leafs_count == leafs_maxcount) {
 				leafs_overflow = true;
 				return;
@@ -510,7 +502,7 @@ static void FindTouchedLeafs_r (const cnode_t *node)
 
 		// NODE_MIXED
 		splitplane = node->plane;
-		sides = BOX_ON_PLANE_SIDE (leafs_mins, leafs_maxs, splitplane);
+		sides = BOX_ON_PLANE_SIDE(leafs_mins, leafs_maxs, splitplane);
 
 		// recurse down the contacted sides
 		if (sides == 1) {
@@ -519,12 +511,11 @@ static void FindTouchedLeafs_r (const cnode_t *node)
 		else if (sides == 2) {
 			node = node->children[1];
 		}
-		else
-		{
+		else {
 			if (leafs_topnode == -1) {
 				leafs_topnode = node - map_nodes;
 			}
-			FindTouchedLeafs_r (node->children[0]);
+			FindTouchedLeafs_r(node->children[0]);
 			node = node->children[1];
 		}
 	}
@@ -694,7 +685,7 @@ static void CM_LoadNodes (lump_t *l)
 	CM_SetParent (map_nodes, NULL); // sets nodes and leafs
 }
 
-static void CM_LoadNodes29a (lump_t *l)
+static void CM_LoadNodes29a(lump_t *l)
 {
 	int i, j, count, p;
 	dnode29a_t *in;
@@ -702,30 +693,28 @@ static void CM_LoadNodes29a (lump_t *l)
 
 	in = (dnode29a_t *)(cmod_base + l->fileofs);
 	if (l->filelen % sizeof(*in))
-		Host_Error ("CM_LoadMap: funny lump size");
+		Host_Error("CM_LoadMap: funny lump size");
 
 	count = l->filelen / sizeof(*in);
-	out = Hunk_AllocName ( count*sizeof(*out), loadname);
+	out = (cnode_t *)Hunk_AllocName(count * sizeof(*out), loadname);
 
 	map_nodes = out;
 	numnodes = count;
 
-	for (i = 0; i < count; i++, in++, out++)
-	{
+	for (i = 0; i < count; i++, in++, out++) {
 		p = LittleLong(in->planenum);
 		out->plane = map_planes + p;
 
-		for (j=0 ; j<2 ; j++)
-		{
-			p = LittleLong (in->children[j]);
+		for (j = 0; j < 2; j++) {
+			p = LittleLong(in->children[j]);
 			out->children[j] = (p >= 0) ? (map_nodes + p) : ((cnode_t *)(map_leafs + (-1 - p)));
 		}
 	}
 
-	CM_SetParent (map_nodes, NULL); // sets nodes and leafs
+	CM_SetParent(map_nodes, NULL); // sets nodes and leafs
 }
 
-static void CM_LoadNodesBSP2 (lump_t *l)
+static void CM_LoadNodesBSP2(lump_t *l)
 {
 	int i, j, count, p;
 	dnode_bsp2_t *in;
@@ -733,27 +722,25 @@ static void CM_LoadNodesBSP2 (lump_t *l)
 
 	in = (dnode_bsp2_t *)(cmod_base + l->fileofs);
 	if (l->filelen % sizeof(*in))
-		Host_Error ("CM_LoadMap: funny lump size");
+		Host_Error("CM_LoadMap: funny lump size");
 
 	count = l->filelen / sizeof(*in);
-	out = Hunk_AllocName ( count*sizeof(*out), loadname);
+	out = (cnode_t *)Hunk_AllocName(count * sizeof(*out), loadname);
 
 	map_nodes = out;
 	numnodes = count;
 
-	for (i = 0; i < count; i++, in++, out++)
-	{
+	for (i = 0; i < count; i++, in++, out++) {
 		p = LittleLong(in->planenum);
 		out->plane = map_planes + p;
 
-		for (j=0 ; j<2 ; j++)
-		{
-			p = LittleLong (in->children[j]);
+		for (j = 0; j < 2; j++) {
+			p = LittleLong(in->children[j]);
 			out->children[j] = (p >= 0) ? (map_nodes + p) : ((cnode_t *)(map_leafs + (-1 - p)));
 		}
 	}
 
-	CM_SetParent (map_nodes, NULL); // sets nodes and leafs
+	CM_SetParent(map_nodes, NULL); // sets nodes and leafs
 }
 
 /*
@@ -769,7 +756,6 @@ static void CM_LoadLeafs (lump_t *l)
 
 	if (l->filelen % sizeof(*in))
 		Host_Error ("CM_LoadMap: funny lump size");
-
 	count = l->filelen / sizeof(*in);
 	out = (cleaf_t *) Hunk_AllocName ( count*sizeof(*out), loadname);
 
@@ -784,7 +770,6 @@ static void CM_LoadLeafs (lump_t *l)
 	}
 }
 
-
 static void CM_LoadLeafs29a (lump_t *l)
 {
 	dleaf29a_t *in;
@@ -793,7 +778,6 @@ static void CM_LoadLeafs29a (lump_t *l)
 	int i, j, count, p;
 
 	in = (dleaf29a_t *)(cmod_base + l->fileofs);
-
 	if (l->filelen % sizeof(*in)) {
 		Host_Error("CM_LoadMap: funny lump size");
 	}
@@ -845,32 +829,29 @@ static void CM_LoadLeafsBSP2 (lump_t *l)
 CM_LoadClipnodes
 =================
 */
-static void CM_LoadClipnodes (lump_t *l)
+static void CM_LoadClipnodes(lump_t *l)
 {
 	dclipnode_t *in;
 	mclipnode_t *out;
 	int i, count;
 
-	in = (dclipnode_t *) (cmod_base + l->fileofs);
-
+	in = (dclipnode_t *)(cmod_base + l->fileofs);
 	if (l->filelen % sizeof(*in))
-		Host_Error ("CM_LoadMap: funny lump size");
-
+		Host_Error("CM_LoadMap: funny lump size");
 	count = l->filelen / sizeof(*in);
-	out = (mclipnode_t *) Hunk_AllocName ( count*sizeof(*out), loadname);
+	out = (mclipnode_t *)Hunk_AllocName(count * sizeof(*out), loadname);
 
 	map_clipnodes = out;
 	numclipnodes = count;
 
-	for (i = 0; i < count; i++, out++, in++)
-	{
+	for (i = 0; i < count; i++, out++, in++) {
 		out->planenum = LittleLong(in->planenum);
 		out->children[0] = LittleShort(in->children[0]);
 		out->children[1] = LittleShort(in->children[1]);
 	}
 }
 
-static void CM_LoadClipnodesBSP2 (lump_t *l)
+static void CM_LoadClipnodesBSP2(lump_t *l)
 {
 	dclipnode29a_t *in;
 	mclipnode_t *out;
@@ -878,15 +859,14 @@ static void CM_LoadClipnodesBSP2 (lump_t *l)
 
 	in = (void *)(cmod_base + l->fileofs);
 	if (l->filelen % sizeof(*in))
-		Host_Error ("CM_LoadMap: funny lump size");
+		Host_Error("CM_LoadMap: funny lump size");
 	count = l->filelen / sizeof(*in);
-	out = Hunk_AllocName ( count*sizeof(*out), loadname);
+	out = Hunk_AllocName(count * sizeof(*out), loadname);
 
 	map_clipnodes = out;
 	numclipnodes = count;
 
-	for (i = 0; i < count; i++, out++, in++)
-	{
+	for (i = 0; i < count; i++, out++, in++) {
 		out->planenum = LittleLong(in->planenum);
 		out->children[0] = LittleLong(in->children[0]);
 		out->children[1] = LittleLong(in->children[1]);
@@ -900,7 +880,7 @@ CM_MakeHull0
 Deplicate the drawing hull structure as a clipping hull
 =================
 */
-static void CM_MakeHull0 (void)
+static void CM_MakeHull0(void)
 {
 	cnode_t *in, *child;
 	mclipnode_t *out;
@@ -908,7 +888,7 @@ static void CM_MakeHull0 (void)
 
 	in = map_nodes;
 	count = numnodes;
-	out = (mclipnode_t *) Hunk_AllocName (count*sizeof(*out), loadname);
+	out = (mclipnode_t *)Hunk_AllocName(count * sizeof(*out), loadname);
 
 	// fix up hull 0 in all cmodels
 	for (i = 0; i < numcmodels; i++) {
@@ -917,24 +897,21 @@ static void CM_MakeHull0 (void)
 	}
 
 	// build clipnodes from nodes
-	for (i = 0; i < count; i++, out++, in++)
-	{
+	for (i = 0; i < count; i++, out++, in++) {
 		out->planenum = in->plane - map_planes;
-		for (j = 0; j < 2; j++)
-		{
+		for (j = 0; j < 2; j++) {
 			child = in->children[j];
 			out->children[j] = (child->contents < 0) ? (child->contents) : (child - map_nodes);
 		}
 	}
 }
 
-
 /*
 =================
 CM_LoadPlanes
 =================
 */
-static void CM_LoadPlanes (lump_t *l)
+static void CM_LoadPlanes(lump_t *l)
 {
 	int i, j, count, bits;
 	mplane_t *out;
@@ -943,26 +920,24 @@ static void CM_LoadPlanes (lump_t *l)
 	in = (dplane_t *)(cmod_base + l->fileofs);
 
 	if (l->filelen % sizeof(*in))
-		Host_Error ("CM_LoadMap: funny lump size");
+		Host_Error("CM_LoadMap: funny lump size");
 
 	count = l->filelen / sizeof(*in);
-	out = (mplane_t *) Hunk_AllocName (count * sizeof(*out), loadname);
-	
+	out = (mplane_t *)Hunk_AllocName(count * sizeof(*out), loadname);
+
 	map_planes = out;
 	numplanes = count;
 
-	for (i = 0; i < count; i++, in++, out++)
-	{
+	for (i = 0; i < count; i++, in++, out++) {
 		bits = 0;
-		for (j=0 ; j<3 ; j++)
-		{
-			out->normal[j] = LittleFloat (in->normal[j]);
+		for (j = 0; j < 3; j++) {
+			out->normal[j] = LittleFloat(in->normal[j]);
 			if (out->normal[j] < 0)
-				bits |= 1<<j;
+				bits |= 1 << j;
 		}
 
-		out->dist = LittleFloat (in->dist);
-		out->type = LittleLong (in->type);
+		out->dist = LittleFloat(in->dist);
+		out->type = LittleLong(in->type);
 		out->signbits = bits;
 	}
 }
@@ -971,37 +946,32 @@ static void CM_LoadPlanes (lump_t *l)
 /*
 ** DecompressVis
 */
-static byte *DecompressVis (byte *in)
+static byte *DecompressVis(byte *in)
 {
-	static byte decompressed[MAX_MAP_LEAFS/8];
+	static byte decompressed[MAX_MAP_LEAFS / 8];
 	int c, row;
 	byte *out;
 
 	row = (visleafs + 7) >> 3;
 	out = decompressed;
 
-	if (!in)
-	{ // no vis info, so make all visible
-		while (row)
-		{
+	if (!in) { // no vis info, so make all visible
+		while (row) {
 			*out++ = 0xff;
 			row--;
 		}
 		return decompressed;
 	}
 
-	do
-	{
-		if (*in)
-		{
+	do {
+		if (*in) {
 			*out++ = *in++;
 			continue;
 		}
 
 		c = in[1];
 		in += 2;
-		while (c)
-		{
+		while (c) {
 			*out++ = 0;
 			c--;
 		}
@@ -1016,7 +986,7 @@ static byte *DecompressVis (byte *in)
 **
 ** Call after CM_LoadLeafs!
 */
-static void CM_BuildPVS (lump_t *lump_vis, lump_t *lump_leafs)
+static void CM_BuildPVS(lump_t *lump_vis, lump_t *lump_leafs)
 {
 	byte *visdata, *scan;
 	dleaf_t *in;
@@ -1024,10 +994,10 @@ static void CM_BuildPVS (lump_t *lump_vis, lump_t *lump_leafs)
 
 	map_vis_rowlongs = (visleafs + 31) >> 5;
 	map_vis_rowbytes = map_vis_rowlongs * 4;
-	map_pvs = (byte *) Hunk_Alloc (map_vis_rowbytes * visleafs);
+	map_pvs = (byte *)Hunk_Alloc(map_vis_rowbytes * visleafs);
 
 	if (!lump_vis->filelen) {
-		memset (map_pvs, 0xff, map_vis_rowbytes * visleafs);
+		memset(map_pvs, 0xff, map_vis_rowbytes * visleafs);
 		return;
 	}
 
@@ -1039,14 +1009,13 @@ static void CM_BuildPVS (lump_t *lump_vis, lump_t *lump_leafs)
 	in = (dleaf_t *)(cmod_base + lump_leafs->fileofs);
 	in++; // pvs row 0 is leaf 1
 	scan = map_pvs;
-	for (i = 0; i < visleafs; i++, in++, scan += map_vis_rowbytes)
-	{
+	for (i = 0; i < visleafs; i++, in++, scan += map_vis_rowbytes) {
 		int p = LittleLong(in->visofs);
-		memcpy (scan, (p == -1) ? map_novis : DecompressVis (visdata + p), map_vis_rowbytes);
+		memcpy(scan, (p == -1) ? map_novis : DecompressVis(visdata + p), map_vis_rowbytes);
 	}
 }
 
-static void CM_BuildPVS29a (lump_t *lump_vis, lump_t *lump_leafs)
+static void CM_BuildPVS29a(lump_t *lump_vis, lump_t *lump_leafs)
 {
 	byte *visdata, *scan;
 	dleaf29a_t *in;
@@ -1054,10 +1023,10 @@ static void CM_BuildPVS29a (lump_t *lump_vis, lump_t *lump_leafs)
 
 	map_vis_rowlongs = (visleafs + 31) >> 5;
 	map_vis_rowbytes = map_vis_rowlongs * 4;
-	map_pvs = Hunk_Alloc (map_vis_rowbytes * visleafs);
+	map_pvs = (byte *)Hunk_Alloc(map_vis_rowbytes * visleafs);
 
 	if (!lump_vis->filelen) {
-		memset (map_pvs, 0xff, map_vis_rowbytes * visleafs);
+		memset(map_pvs, 0xff, map_vis_rowbytes * visleafs);
 		return;
 	}
 
@@ -1069,14 +1038,13 @@ static void CM_BuildPVS29a (lump_t *lump_vis, lump_t *lump_leafs)
 	in = (dleaf29a_t *)(cmod_base + lump_leafs->fileofs);
 	in++; // pvs row 0 is leaf 1
 	scan = map_pvs;
-	for (i = 0; i < visleafs; i++, in++, scan += map_vis_rowbytes)
-	{
+	for (i = 0; i < visleafs; i++, in++, scan += map_vis_rowbytes) {
 		int p = LittleLong(in->visofs);
-		memcpy (scan, (p == -1) ? map_novis : DecompressVis (visdata + p), map_vis_rowbytes);
+		memcpy(scan, (p == -1) ? map_novis : DecompressVis(visdata + p), map_vis_rowbytes);
 	}
 }
 
-static void CM_BuildPVSBSP2 (lump_t *lump_vis, lump_t *lump_leafs)
+static void CM_BuildPVSBSP2(lump_t *lump_vis, lump_t *lump_leafs)
 {
 	byte *visdata, *scan;
 	dleaf_bsp2_t *in;
@@ -1084,10 +1052,10 @@ static void CM_BuildPVSBSP2 (lump_t *lump_vis, lump_t *lump_leafs)
 
 	map_vis_rowlongs = (visleafs + 31) >> 5;
 	map_vis_rowbytes = map_vis_rowlongs * 4;
-	map_pvs = Hunk_Alloc (map_vis_rowbytes * visleafs);
+	map_pvs = (byte *)Hunk_Alloc(map_vis_rowbytes * visleafs);
 
 	if (!lump_vis->filelen) {
-		memset (map_pvs, 0xff, map_vis_rowbytes * visleafs);
+		memset(map_pvs, 0xff, map_vis_rowbytes * visleafs);
 		return;
 	}
 
@@ -1099,13 +1067,11 @@ static void CM_BuildPVSBSP2 (lump_t *lump_vis, lump_t *lump_leafs)
 	in = (dleaf_bsp2_t *)(cmod_base + lump_leafs->fileofs);
 	in++; // pvs row 0 is leaf 1
 	scan = map_pvs;
-	for (i = 0; i < visleafs; i++, in++, scan += map_vis_rowbytes)
-	{
+	for (i = 0; i < visleafs; i++, in++, scan += map_vis_rowbytes) {
 		int p = LittleLong(in->visofs);
-		memcpy (scan, (p == -1) ? map_novis : DecompressVis (visdata + p), map_vis_rowbytes);
+		memcpy(scan, (p == -1) ? map_novis : DecompressVis(visdata + p), map_vis_rowbytes);
 	}
 }
-
 
 /*
 ** CM_BuildPHS
@@ -1176,11 +1142,12 @@ void CM_InvalidateMap (void)
 /*
 ** CM_LoadMap
 */
-extern cvar_t sv_halflifebsp;
 typedef void(*BuildPVSFunction)(lump_t *lump_vis, lump_t *lump_leafs);
 cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned *checksum2)
 {
-	extern cvar_t sv_bspversion;
+#ifndef CLIENTONLY
+	extern cvar_t sv_bspversion, sv_halflifebsp;
+#endif
 
 	unsigned int i;
 	dheader_t *header;
@@ -1211,8 +1178,10 @@ cmodel_t *CM_LoadMap (char *name, qbool clientload, unsigned *checksum, unsigned
 
 	map_halflife = (i == HL_BSPVERSION);
 
+#ifndef CLIENTONLY
 	Cvar_SetROM(&sv_halflifebsp, map_halflife ? "1" : "0");
 	Cvar_SetROM(&sv_bspversion, i == Q1_BSPVERSION || i == HL_BSPVERSION ? "1" : "2");
+#endif
 
 	// swap all the lumps
 	cmod_base = (byte *)header;

--- a/src/cmodel.h
+++ b/src/cmodel.h
@@ -45,7 +45,7 @@ typedef struct mplane_s
 // !!! if this is changed, it must be changed in asm_i386.h too !!!
 typedef struct
 {
-	dclipnode_t	*clipnodes;
+	mclipnode_t	*clipnodes;
 	mplane_t	*planes;
 	int			firstclipnode;
 	int			lastclipnode;

--- a/src/cmodel.h
+++ b/src/cmodel.h
@@ -33,8 +33,7 @@ enum {
 
 // plane_t structure
 // !!! if this is changed, it must be changed in asm_i386.h too !!!
-typedef struct mplane_s
-{
+typedef struct mplane_s {
 	vec3_t	normal;
 	float	dist;
 	byte	type;			// for texture axis selection and fast side tests
@@ -43,8 +42,7 @@ typedef struct mplane_s
 } mplane_t;
 
 // !!! if this is changed, it must be changed in asm_i386.h too !!!
-typedef struct
-{
+typedef struct {
 	mclipnode_t	*clipnodes;
 	mplane_t	*planes;
 	int			firstclipnode;
@@ -53,14 +51,12 @@ typedef struct
 	vec3_t		clip_maxs;
 } hull_t;
 
-typedef struct
-{
+typedef struct {
 	vec3_t	normal;
 	float	dist;
 } plane_t;
 
-typedef struct
-{
+typedef struct {
 	qbool	allsolid;			// if true, plane is not valid
 	qbool	startsolid;			// if true, the initial point was in a solid area
 	qbool	inopen, inwater;

--- a/src/common.c
+++ b/src/common.c
@@ -1851,3 +1851,20 @@ int Com_TranslateMapChecksum (const char *mapname, int checksum)
 	return checksum;
 }
 
+qbool COM_FileExists (char *path)
+{
+	FILE *fexists = NULL;
+
+	// Try opening the file to see if it exists.
+	fexists = fopen(path, "rb");
+
+	// The file exists.
+	if (fexists)
+	{
+		// Make sure the file is closed.
+		fclose (fexists);
+		return true;
+	}
+
+	return false;
+}

--- a/src/common.c
+++ b/src/common.c
@@ -1354,7 +1354,7 @@ qbool Info_Set (ctxinfo_t *ctx, const char *name, const char *value)
 
 	if (name[0] == '*')
 	{
-		Con_Printf ("Can't set * keys\n");
+		Con_Printf ("Can't set * keys [%s]\n", name);
 		return false;
 	}
 

--- a/src/common.c
+++ b/src/common.c
@@ -198,6 +198,13 @@ void MSG_WriteCoord (sizebuf_t *sb, const float f)
 #endif
 }
 
+void MSG_WriteLongCoord(sizebuf_t* sb, float f)
+{
+	f = LittleFloat(f);
+
+	SZ_Write (sb, (void*)&f, sizeof(f));
+}
+
 void MSG_WriteAngle (sizebuf_t *sb, const float f)
 {
 #ifdef FTE_PEXT_FLOATCOORDS

--- a/src/common.h
+++ b/src/common.h
@@ -71,6 +71,7 @@ void MSG_WriteString (sizebuf_t *sb, const char *s);
 void MSG_WriteCoord (sizebuf_t *sb, const float f);
 void MSG_WriteAngle (sizebuf_t *sb, const float f);
 void MSG_WriteAngle16 (sizebuf_t *sb, const float f);
+void MSG_WriteLongCoord (sizebuf_t* sb, float f);
 void MSG_WriteDeltaUsercmd (sizebuf_t *sb, const struct usercmd_s *from, const struct usercmd_s *cmd);
 
 extern int msg_readcount;

--- a/src/common.h
+++ b/src/common.h
@@ -220,5 +220,6 @@ typedef struct qtvuser_s
 
 //============================================================================
 
+qbool COM_FileExists(char *path);
 
 #endif /* !__COMMON_H__ */

--- a/src/fs.c
+++ b/src/fs.c
@@ -462,7 +462,7 @@ void FS_SetGamedir (char *dir, qbool force)
 
 	if (!force && !strcmp(fs_gamedirfile, dir))
 		return;		// Still the same, unless we forced.
-	
+
 	// FIXME: do we need it? since it will be set in FS_AddGameDirectory().
 	strlcpy (fs_gamedirfile, dir, sizeof(fs_gamedirfile));
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -1011,3 +1011,20 @@ char *FS_NextPath (char *prevpath)
 	return NULL;
 }
 
+/*
+===========
+FS_UnsafeFilename
+
+Returns true if user-specified path is unsafe
+===========
+*/
+qbool FS_UnsafeFilename(const char* fileName)
+{
+	return !fileName ||
+		!*fileName || // invalid name.
+		fileName[1] == ':' ||	// dos filename absolute path specified - reject.
+		*fileName == '\\' ||
+		*fileName == '/' ||	// absolute path was given - reject.
+		strstr(fileName, "..");
+}
+

--- a/src/fs.h
+++ b/src/fs.h
@@ -52,4 +52,6 @@ void FS_CreatePath (char *path);
 char *FS_NextPath (char *prevpath);
 void FS_SetGamedir (char *dir, qbool force);
 
+qbool FS_UnsafeFilename(const char* name);
+
 #endif /* !__FS_H__ */

--- a/src/g_public.h
+++ b/src/g_public.h
@@ -30,7 +30,7 @@
 //
 // g_public.h -- game module information visible to server
 
-#define	GAME_API_VERSION	14
+#define	GAME_API_VERSION	15
 
 
 //===============================================================
@@ -188,7 +188,7 @@ typedef enum
 	// and parameters.  Return qfalse if the game doesn't recognize it as a command.
 	GAME_CLIENT_SAY,			// ( int isTeamSay );
 	GAME_PAUSED_TIC,			// ( int duration_msec );	// duration is in msecs
-
+	GAME_CLEAR_EDICT,           // (self)
 } gameExport_t;
 
 
@@ -208,9 +208,9 @@ typedef enum
 
 typedef struct
 {
-	string_t	name;
-	int			ofs;
-	fieldtype_t	type;
+	stringptr_t   name;
+	int           ofs;
+	fieldtype_t   type;
 //	int			flags;
 } field_t;
 

--- a/src/g_public.h
+++ b/src/g_public.h
@@ -30,7 +30,7 @@
 //
 // g_public.h -- game module information visible to server
 
-#define	GAME_API_VERSION	13
+#define	GAME_API_VERSION	14
 
 
 //===============================================================
@@ -216,11 +216,12 @@ typedef struct
 
 typedef struct
 {
-	edict_t		*ents;
-	int		sizeofent;
-	globalvars_t	*global;
-	field_t		*fields;
-	int 		APIversion;
+	edict_t         *ents;
+	int             sizeofent;
+	globalvars_t    *global;
+	field_t         *fields;
+	int             APIversion;
+	int             maxentities;
 } gameData_t;
 
 typedef int		fileHandle_t;

--- a/src/g_public.h
+++ b/src/g_public.h
@@ -211,7 +211,6 @@ typedef struct
 	stringptr_t   name;
 	int           ofs;
 	fieldtype_t   type;
-//	int			flags;
 } field_t;
 
 typedef struct

--- a/src/mathlib.c
+++ b/src/mathlib.c
@@ -16,12 +16,15 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  
-	
+
 */
 // mathlib.c -- math primitives
 
+#ifdef SERVERONLY
 #include "qwsvdef.h"
-
+#else
+#include "common.h"
+#endif
 
 vec3_t vec3_origin = {0,0,0};
 

--- a/src/pmove.c
+++ b/src/pmove.c
@@ -19,19 +19,26 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 	
 */
 
+#ifdef SERVERONLY
 #include "qwsvdef.h"
+#else
+#include "quakedef.h"
+#include "pmove.h"
+#endif
 
-movevars_t		movevars;
-playermove_t	pmove;
+movevars_t      movevars;
+playermove_t    pmove;
 
 static float	pm_frametime;
 
 static vec3_t	pm_forward, pm_right;
 
+static plane_t groundplane;
+
 vec3_t	player_mins = {-16, -16, -24};
 vec3_t	player_maxs = {16, 16, 32};
 
-#define STEPSIZE		18
+#define STEPSIZE        18
 #define MIN_STEP_NORMAL	0.7 // roughly 45 degrees
 
 #define pm_flyfriction	4
@@ -40,8 +47,6 @@ vec3_t	player_maxs = {16, 16, 32};
 #define BLOCKED_STEP	2
 #define BLOCKED_OTHER	4
 #define BLOCKED_ANY		7
-
-
 
 // Add an entity to touch list, discarding duplicates
 static void PM_AddTouchedEnt (int num)
@@ -69,8 +74,7 @@ static void PM_ClipVelocity (vec3_t in, vec3_t normal, vec3_t out, float overbou
 
 	backoff = DotProduct (in, normal) * overbounce;
 
-	for (i = 0; i < 3; i++)
-	{
+	for (i = 0; i < 3; i++) {
 		change = normal[i] * backoff;
 		out[i] = in[i] - change;
 		if (out[i] > -STOP_EPSILON && out[i] < STOP_EPSILON)
@@ -95,27 +99,25 @@ static int PM_SlideMove (void)
 
 	time_left = pm_frametime;
 
-	for (bumpcount = 0; bumpcount < numbumps; bumpcount++)
-	{
+	for (bumpcount = 0; bumpcount < numbumps; bumpcount++) {
 		VectorMA(pmove.origin, time_left, pmove.velocity, end);
 		trace = PM_PlayerTrace (pmove.origin, end);
 
-		if (trace.startsolid || trace.allsolid)
-		{
+		if (trace.startsolid || trace.allsolid) {
 			// entity is trapped in another solid
 			VectorClear (pmove.velocity);
 			return 3;
 		}
 
-		if (trace.fraction > 0)
-		{
+		if (trace.fraction > 0) {
 			// actually covered some distance
 			VectorCopy (trace.endpos, pmove.origin);
 			numplanes = 0;
 		}
 
-		if (trace.fraction == 1)
+		if (trace.fraction == 1) {
 			break; // moved the entire distance
+		}
 
 		// save entity for contact
 		PM_AddTouchedEnt (trace.e.entnum);
@@ -130,8 +132,7 @@ static int PM_SlideMove (void)
 		time_left -= time_left * trace.fraction;
 
 		// cliped to another plane
-		if (numplanes >= MAX_CLIP_PLANES)
-		{
+		if (numplanes >= MAX_CLIP_PLANES) {
 			// this shouldn't really happen
 			VectorClear (pmove.velocity);
 			break;
@@ -141,30 +142,26 @@ static int PM_SlideMove (void)
 		numplanes++;
 
 		// modify original_velocity so it parallels all of the clip planes
-		for (i = 0; i < numplanes; i++)
-		{
+		for (i = 0; i < numplanes; i++) {
 			PM_ClipVelocity (original_velocity, planes[i], pmove.velocity, 1);
-			for (j = 0; j < numplanes; j++)
-			{
-				if (j != i)
-				{
-					if (DotProduct (pmove.velocity, planes[j]) < 0)
+			for (j = 0; j < numplanes; j++) {
+				if (j != i) {
+					if (DotProduct(pmove.velocity, planes[j]) < 0) {
 						break; // not ok
+					}
 				}
 			}
-			if (j == numplanes)
+			if (j == numplanes) {
 				break;
+			}
 		}
 
-		if (i != numplanes)
-		{
+		if (i != numplanes) {
 			// go along this plane
 		}
-		else
-		{
+		else {
 			// go along the crease
-			if (numplanes != 2)
-			{
+			if (numplanes != 2) {
 				VectorClear (pmove.velocity);
 				break;
 			}
@@ -175,15 +172,15 @@ static int PM_SlideMove (void)
 
 		// if velocity is against the original velocity, stop dead
 		// to avoid tiny occilations in sloping corners
-		if (DotProduct (pmove.velocity, primal_velocity) <= 0)
-		{
+		if (DotProduct (pmove.velocity, primal_velocity) <= 0) {
 			VectorClear (pmove.velocity);
 			break;
 		}
 	}
 
-	if (pmove.waterjumptime)
-		VectorCopy (primal_velocity, pmove.velocity);
+	if (pmove.waterjumptime) {
+		VectorCopy(primal_velocity, pmove.velocity);
+	}
 
 	return blocked;
 }
@@ -203,31 +200,32 @@ static int PM_StepSlideMove (qbool in_air)
 
 	blocked = PM_SlideMove ();
 
-	if (!blocked)
+	if (!blocked) {
 		return blocked; // moved the entire distance
+	}
 
-	if (in_air)
-	{
+	if (in_air) {
 		// don't let us step up unless it's indeed a step we bumped in
 		// (that is, there's solid ground below)
 		float *org;
 
-		if (!(blocked & BLOCKED_STEP))
+		if (!(blocked & BLOCKED_STEP)) {
 			return blocked;
+		}
 
 		org = (originalvel[2] < 0) ? pmove.origin : original;
 		VectorCopy (org, dest);
 		dest[2] -= STEPSIZE;
 		trace = PM_PlayerTrace (org, dest);
-		if (trace.fraction == 1 || trace.plane.normal[2] < MIN_STEP_NORMAL)
+		if (trace.fraction == 1 || trace.plane.normal[2] < MIN_STEP_NORMAL) {
 			return blocked;
+		}
 
 		// adjust stepsize, otherwise it would be possible to walk up a
 		// a step higher than STEPSIZE
 		stepsize = STEPSIZE - (org[2] - trace.endpos[2]);
 	}
-	else
-	{
+	else {
 		stepsize = STEPSIZE;
 	}
 
@@ -241,11 +239,13 @@ static int PM_StepSlideMove (qbool in_air)
 	VectorCopy (pmove.origin, dest);
 	dest[2] += stepsize;
 	trace = PM_PlayerTrace (pmove.origin, dest);
-	if (!trace.startsolid && !trace.allsolid)
-		VectorCopy (trace.endpos, pmove.origin);
+	if (!trace.startsolid && !trace.allsolid) {
+		VectorCopy(trace.endpos, pmove.origin);
+	}
 
-	if (in_air && originalvel[2] < 0)
+	if (in_air && originalvel[2] < 0) {
 		pmove.velocity[2] = 0;
+	}
 
 	PM_SlideMove ();
 
@@ -253,13 +253,16 @@ static int PM_StepSlideMove (qbool in_air)
 	VectorCopy (pmove.origin, dest);
 	dest[2] -= stepsize;
 	trace = PM_PlayerTrace (pmove.origin, dest);
-	if (trace.fraction != 1 && trace.plane.normal[2] < MIN_STEP_NORMAL)
+	if (trace.fraction != 1 && trace.plane.normal[2] < MIN_STEP_NORMAL) {
 		goto usedown;
-	if (!trace.startsolid && !trace.allsolid)
-		VectorCopy (trace.endpos, pmove.origin);
+	}
+	if (!trace.startsolid && !trace.allsolid) {
+		VectorCopy(trace.endpos, pmove.origin);
+	}
 
-	if (pmove.origin[2] < original[2])
+	if (pmove.origin[2] < original[2]) {
 		goto usedown;
+	}
 
 	VectorCopy (pmove.origin, up);
 
@@ -269,8 +272,7 @@ static int PM_StepSlideMove (qbool in_air)
 	updist = (up[0] - original[0]) * (up[0] - original[0])
 		+ (up[1] - original[1]) * (up[1] - original[1]);
 
-	if (downdist >= updist)
-	{
+	if (downdist >= updist) {
 usedown:
 		VectorCopy (down, pmove.origin);
 		VectorCopy (downvel, pmove.velocity);
@@ -280,8 +282,7 @@ usedown:
 	// copy z value from slide move
 	pmove.velocity[2] = downvel[2];
 
-	if (!pmove.onground && pmove.waterlevel < 2 && (blocked & BLOCKED_STEP))
-	{
+	if (!pmove.onground && pmove.waterlevel < 2 && (blocked & BLOCKED_STEP)) {
 		float scale;
 		// in pm_airstep mode, walking up a 16 unit high step
 		// will kill 16% of horizontal velocity
@@ -294,7 +295,7 @@ usedown:
 }
 
 //Handles both ground friction and water friction
-static void PM_Friction (void)
+static void PM_Friction(void)
 {
 	float speed, newspeed, control, friction, drop;
 	vec3_t start, stop;
@@ -303,55 +304,53 @@ static void PM_Friction (void)
 	if (pmove.waterjumptime)
 		return;
 
-	speed = VectorLength (pmove.velocity);
-	if (speed < 1)
-	{
+	speed = VectorLength(pmove.velocity);
+	if (speed < 1) {
 		pmove.velocity[0] = pmove.velocity[1] = 0;
-		if (pmove.pm_type == PM_FLY)
+		if (pmove.pm_type == PM_FLY) {
 			pmove.velocity[2] = 0;
+		}
 		return;
 	}
 
-	if (pmove.waterlevel >= 2)
-	{
+	if (pmove.waterlevel >= 2) {
 		// apply water friction, even if in fly mode
 		drop = speed * movevars.waterfriction * pmove.waterlevel * pm_frametime;
 	}
-	else if (pmove.pm_type == PM_FLY)
-	{
+	else if (pmove.pm_type == PM_FLY) {
 		// apply flymode friction
 		drop = speed * pm_flyfriction * pm_frametime;
 	}
-	else if (pmove.onground)
-	{
+	else if (pmove.onground) {
 		// apply ground friction
 		friction = movevars.friction;
 
 		// if the leading edge is over a dropoff, increase friction
-		start[0] = stop[0] = pmove.origin[0] + pmove.velocity[0]/speed*16;
-		start[1] = stop[1] = pmove.origin[1] + pmove.velocity[1]/speed*16;
+		start[0] = stop[0] = pmove.origin[0] + pmove.velocity[0] / speed * 16;
+		start[1] = stop[1] = pmove.origin[1] + pmove.velocity[1] / speed * 16;
 		start[2] = pmove.origin[2] + player_mins[2];
 		stop[2] = start[2] - 34;
-		trace = PM_PlayerTrace (start, stop);
-		if (trace.fraction == 1)
+		trace = PM_PlayerTrace(start, stop);
+		if (trace.fraction == 1) {
 			friction *= 2;
+		}
 
 		control = speed < movevars.stopspeed ? movevars.stopspeed : speed;
 		drop = control * friction * pm_frametime;
 	}
-	else
+	else {
 		return; // in air, no friction
-
+	}
 
 	// scale the velocity
 	newspeed = speed - drop;
 	newspeed = max(newspeed, 0);
 	newspeed /= speed;
 
-	VectorScale (pmove.velocity, newspeed, pmove.velocity);
+	VectorScale(pmove.velocity, newspeed, pmove.velocity);
 }
 
-static void PM_Accelerate (vec3_t wishdir, float wishspeed, float accel)
+static void PM_Accelerate(vec3_t wishdir, float wishspeed, float accel)
 {
 	float addspeed, accelspeed, currentspeed;
 
@@ -360,7 +359,7 @@ static void PM_Accelerate (vec3_t wishdir, float wishspeed, float accel)
 	if (pmove.waterjumptime)
 		return;
 
-	currentspeed = DotProduct (pmove.velocity, wishdir);
+	currentspeed = DotProduct(pmove.velocity, wishdir);
 	addspeed = wishspeed - currentspeed;
 	if (addspeed <= 0)
 		return;
@@ -371,7 +370,15 @@ static void PM_Accelerate (vec3_t wishdir, float wishspeed, float accel)
 	VectorMA(pmove.velocity, accelspeed, wishdir, pmove.velocity);
 }
 
-static void PM_AirAccelerate (vec3_t wishdir, float wishspeed, float accel)
+#ifndef SERVERONLY
+#ifdef EXPERIMENTAL_SHOW_ACCELERATION
+qbool player_in_air = false;
+float cosinus_val = 0.f;
+qbool flag_player_pmove;
+#endif
+#endif
+
+static void PM_AirAccelerate(vec3_t wishdir, float wishspeed, float accel)
 {
 	float addspeed, accelspeed, currentspeed, wishspd = wishspeed;
 	float originalspeed = 0.0, newspeed = 0.0, speedcap = 0.0;
@@ -385,8 +392,21 @@ static void PM_AirAccelerate (vec3_t wishdir, float wishspeed, float accel)
 		originalspeed = sqrt(pmove.velocity[0] * pmove.velocity[0] + pmove.velocity[1] * pmove.velocity[1]);
 
 	wishspd = min(wishspd, 30);
-	currentspeed = DotProduct (pmove.velocity, wishdir);
+	currentspeed = DotProduct(pmove.velocity, wishdir);
 	addspeed = wishspd - currentspeed;
+
+#ifdef EXPERIMENTAL_SHOW_ACCELERATION
+	if (flag_player_pmove) {
+		cosinus_val = 0.f;
+		originalspeed = sqrt(pmove.velocity[0] * pmove.velocity[0] + pmove.velocity[1] * pmove.velocity[1]);
+		if (originalspeed > 1.f) {
+			cosinus_val = currentspeed / originalspeed;
+		}
+
+		player_in_air = true;
+	}
+#endif
+
 	if (addspeed <= 0)
 		return;
 	accelspeed = accel * wishspeed * pm_frametime;
@@ -394,14 +414,11 @@ static void PM_AirAccelerate (vec3_t wishdir, float wishspeed, float accel)
 
 	VectorMA(pmove.velocity, accelspeed, wishdir, pmove.velocity);
 
-	if (movevars.bunnyspeedcap > 0)
-	{
+	if (movevars.bunnyspeedcap > 0) {
 		newspeed = sqrt(pmove.velocity[0] * pmove.velocity[0] + pmove.velocity[1] * pmove.velocity[1]);
-		if (newspeed > originalspeed)
-		{
+		if (newspeed > originalspeed) {
 			speedcap = movevars.maxspeed * movevars.bunnyspeedcap;
-			if (newspeed > speedcap)
-			{
+			if (newspeed > speedcap) {
 				if (originalspeed < speedcap)
 					originalspeed = speedcap;
 				pmove.velocity[0] *= originalspeed / newspeed;
@@ -411,7 +428,7 @@ static void PM_AirAccelerate (vec3_t wishdir, float wishspeed, float accel)
 	}
 }
 
-static int PM_WaterMove (void)
+static int PM_WaterMove(void)
 {
 	vec3_t wishvel, wishdir;
 	float wishspeed;
@@ -426,23 +443,22 @@ static int PM_WaterMove (void)
 	else
 		wishvel[2] += pmove.cmd.upmove;
 
-	VectorCopy (wishvel, wishdir);
+	VectorCopy(wishvel, wishdir);
 	wishspeed = VectorNormalize(wishdir);
 
-	if (wishspeed > movevars.maxspeed)
-	{
-		VectorScale (wishvel, movevars.maxspeed/wishspeed, wishvel);
+	if (wishspeed > movevars.maxspeed) {
+		VectorScale(wishvel, movevars.maxspeed / wishspeed, wishvel);
 		wishspeed = movevars.maxspeed;
 	}
 	wishspeed *= 0.7;
 
 	// water acceleration
-	PM_Accelerate (wishdir, wishspeed, movevars.wateraccelerate);
+	PM_Accelerate(wishdir, wishspeed, movevars.wateraccelerate);
 
-	return PM_StepSlideMove (false);
+	return PM_StepSlideMove(false);
 }
 
-static int PM_FlyMove (void)
+static int PM_FlyMove(void)
 {
 	vec3_t wishvel, wishdir;
 	float wishspeed;
@@ -453,20 +469,19 @@ static int PM_FlyMove (void)
 
 	wishvel[2] += pmove.cmd.upmove;
 
-	VectorCopy (wishvel, wishdir);
+	VectorCopy(wishvel, wishdir);
 	wishspeed = VectorNormalize(wishdir);
 
-	if (wishspeed > movevars.maxspeed)
-	{
-		VectorScale (wishvel, movevars.maxspeed/wishspeed, wishvel);
+	if (wishspeed > movevars.maxspeed) {
+		VectorScale(wishvel, movevars.maxspeed / wishspeed, wishvel);
 		wishspeed = movevars.maxspeed;
 	}
 
-	PM_Accelerate (wishdir, wishspeed, movevars.accelerate);
-	return PM_StepSlideMove (false);
+	PM_Accelerate(wishdir, wishspeed, movevars.accelerate);
+	return PM_StepSlideMove(false);
 }
 
-static int PM_AirMove (void)
+static int PM_AirMove(void)
 {
 	float fmove, smove, wishspeed;
 	vec3_t wishvel, wishdir;
@@ -477,76 +492,67 @@ static int PM_AirMove (void)
 
 	pm_forward[2] = 0;
 	pm_right[2] = 0;
-	VectorNormalize (pm_forward);
-	VectorNormalize (pm_right);
+	VectorNormalize(pm_forward);
+	VectorNormalize(pm_right);
 
 	for (i = 0; i < 2; i++)
 		wishvel[i] = pm_forward[i] * fmove + pm_right[i] * smove;
 	wishvel[2] = 0;
 
-	VectorCopy (wishvel, wishdir);
+	VectorCopy(wishvel, wishdir);
 	wishspeed = VectorNormalize(wishdir);
 
 	// clamp to server defined max speed
-	if (wishspeed > movevars.maxspeed)
-	{
-		VectorScale (wishvel, movevars.maxspeed/wishspeed, wishvel);
+	if (wishspeed > movevars.maxspeed) {
+		VectorScale(wishvel, movevars.maxspeed / wishspeed, wishvel);
 		wishspeed = movevars.maxspeed;
 	}
 
-	if (pmove.onground)
-	{
-		if (movevars.slidefix)
-		{
+	if (pmove.onground) {
+		if (movevars.slidefix) {
 			pmove.velocity[2] = min(pmove.velocity[2], 0); // bound above by 0
-			PM_Accelerate (wishdir, wishspeed, movevars.accelerate);
+			PM_Accelerate(wishdir, wishspeed, movevars.accelerate);
 			// add gravity
 			pmove.velocity[2] -= movevars.entgravity * movevars.gravity * pm_frametime;
 		}
-		else
-		{
+		else {
 			pmove.velocity[2] = 0;
-			PM_Accelerate (wishdir, wishspeed, movevars.accelerate);
+			PM_Accelerate(wishdir, wishspeed, movevars.accelerate);
 		}
 
-		if (!pmove.velocity[0] && !pmove.velocity[1])
-		{
+		if (!pmove.velocity[0] && !pmove.velocity[1]) {
 			pmove.velocity[2] = 0;
 			return 0;
 		}
 
 		return PM_StepSlideMove(false);
 	}
-	else
-	{
+	else {
 		int blocked;
 		// not on ground, so little effect on velocity
-		PM_AirAccelerate (wishdir, wishspeed, movevars.accelerate);
+		PM_AirAccelerate(wishdir, wishspeed, movevars.accelerate);
 
 		// add gravity
 		pmove.velocity[2] -= movevars.entgravity * movevars.gravity * pm_frametime;
 
 		if (movevars.airstep)
-			blocked = PM_StepSlideMove (true);
+			blocked = PM_StepSlideMove(true);
 		else
-			blocked = PM_SlideMove ();
+			blocked = PM_SlideMove();
 
-		if (movevars.pground)
-		{
-			if (blocked & BLOCKED_FLOOR)
+		if (movevars.pground) {
+			if (blocked & BLOCKED_FLOOR) {
 				pmove.onground = true;
+			}
 		}
 
 		return blocked;
 	}
 }
 
-// FIXME: put at the top of the file?
-static plane_t groundplane;
-
 void PM_CategorizePosition (void)
 {
-	trace_t trace = {0};
+	trace_t trace = { 0 };
 	vec3_t point;
 	int cont;
 
@@ -556,19 +562,15 @@ void PM_CategorizePosition (void)
 	point[0] = pmove.origin[0];
 	point[1] = pmove.origin[1];
 	point[2] = pmove.origin[2] - 1;
-	if (pmove.velocity[2] > 180)
-	{
+	if (pmove.velocity[2] > 180) {
 		pmove.onground = false;
 	}
-	else if (!movevars.pground || pmove.onground)
-	{
+	else if (!movevars.pground || pmove.onground) {
 		trace = PM_PlayerTrace (pmove.origin, point);
-		if (trace.fraction == 1 || trace.plane.normal[2] < MIN_STEP_NORMAL)
-		{
+		if (trace.fraction == 1 || trace.plane.normal[2] < MIN_STEP_NORMAL) {
 			pmove.onground = false;
 		}
-		else
-		{
+		else {
 			pmove.onground = true;
 			pmove.groundent = trace.e.entnum;
 			groundplane = trace.plane;
@@ -576,8 +578,9 @@ void PM_CategorizePosition (void)
 		}
 
 		// standing on an entity other than the world
-		if (trace.e.entnum > 0)
-			PM_AddTouchedEnt (trace.e.entnum);
+		if (trace.e.entnum > 0) {
+			PM_AddTouchedEnt(trace.e.entnum);
+		}
 	}
 
 	// get waterlevel
@@ -586,30 +589,27 @@ void PM_CategorizePosition (void)
 
 	point[2] = pmove.origin[2] + player_mins[2] + 1;
 	cont = PM_PointContents (point);
-
-	if (cont <= CONTENTS_WATER)
-	{
+	if (cont <= CONTENTS_WATER) {
 		pmove.watertype = cont;
 		pmove.waterlevel = 1;
 		point[2] = pmove.origin[2] + (player_mins[2] + player_maxs[2]) * 0.5;
 		cont = PM_PointContents (point);
-		if (cont <= CONTENTS_WATER)
-		{
+		if (cont <= CONTENTS_WATER) {
 			pmove.waterlevel = 2;
 			point[2] = pmove.origin[2] + 22;
 			cont = PM_PointContents (point);
-			if (cont <= CONTENTS_WATER)
+			if (cont <= CONTENTS_WATER) {
 				pmove.waterlevel = 3;
+			}
 		}
 	}
 
-	if (!movevars.pground)
-	{
-		if (pmove.onground && pmove.pm_type != PM_FLY && pmove.waterlevel < 2)
-		{
+	if (!movevars.pground) {
+		if (pmove.onground && pmove.pm_type != PM_FLY && pmove.waterlevel < 2) {
 			// snap to ground so that we can't jump higher than we're supposed to
-			if (!trace.startsolid && !trace.allsolid)
-				VectorCopy (trace.endpos, pmove.origin);
+			if (!trace.startsolid && !trace.allsolid) {
+				VectorCopy(trace.endpos, pmove.origin);
+			}
 		}
 	}
 }
@@ -619,23 +619,21 @@ static void PM_CheckJump (void)
 	if (pmove.pm_type == PM_FLY)
 		return;
 
-	if (pmove.pm_type == PM_DEAD)
-	{
+	if (pmove.pm_type == PM_DEAD) {
 		pmove.jump_held = true; // don't jump on respawn
 		return;
 	}
 
-	if (!(pmove.cmd.buttons & BUTTON_JUMP))
-	{
+	if (!(pmove.cmd.buttons & BUTTON_JUMP)) {
 		pmove.jump_held = false;
 		return;
 	}
 
-	if (pmove.waterjumptime)
+	if (pmove.waterjumptime) {
 		return;
+	}
 
-	if (pmove.waterlevel >= 2)
-	{
+	if (pmove.waterlevel >= 2) {
 		// swimming, not jumping
 		pmove.onground = false;
 
@@ -654,12 +652,10 @@ static void PM_CheckJump (void)
 	if (pmove.jump_held && !pmove.jump_msec)
 		return; // don't pogo stick
 
-	if (!movevars.pground)
-	{
+	if (!movevars.pground) {
 		// check for jump bug
 		// groundplane normal was set in the call to PM_CategorizePosition
-		if (pmove.velocity[2] < 0 && DotProduct(pmove.velocity, groundplane.normal) < -0.1)
-		{
+		if (pmove.velocity[2] < 0 && DotProduct(pmove.velocity, groundplane.normal) < -0.1) {
 			// pmove.velocity is pointing into the ground, clip it
 			PM_ClipVelocity (pmove.velocity, groundplane.normal, pmove.velocity, 1);
 		}
@@ -668,8 +664,7 @@ static void PM_CheckJump (void)
 	pmove.onground = false;
 	pmove.velocity[2] += 270;
 
-	if (movevars.ktjump > 0)
-	{
+	if (movevars.ktjump > 0) {
 		if (movevars.ktjump > 1)
 			movevars.ktjump = 1;
 		if (pmove.velocity[2] < 270)
@@ -729,12 +724,9 @@ static void PM_NudgePosition (void)
 	for (i = 0; i < 3; i++)
 		pmove.origin[i] = ((int) (pmove.origin[i] * 8)) * 0.125;
 
-	for (z = 0; z <= 2; z++)
-	{
-		for (y = 0; y <= 2; y++)
-		{
-			for (x = 0; x <= 2; x++)
-			{
+	for (z = 0; z <= 2; z++) {
+		for (y = 0; y <= 2; y++) {
+			for (x = 0; x <= 2; x++) {
 				pmove.origin[0] = base[0] + (sign[x] * 0.125);
 				pmove.origin[1] = base[1] + (sign[y] * 0.125);
 				pmove.origin[2] = base[2] + (sign[z] * 0.125);
@@ -745,8 +737,7 @@ static void PM_NudgePosition (void)
 	}
 
 	// some maps spawn the player several units into the ground
-	for (z=1 ; z<=18 ; z++)
-	{
+	for (z = 1; z <= 18; z++) {
 		pmove.origin[0] = base[0];
 		pmove.origin[1] = base[1];
 		pmove.origin[2] = base[2] + z;
@@ -757,53 +748,51 @@ static void PM_NudgePosition (void)
 	VectorCopy (base, pmove.origin);
 }
 
-static void PM_SpectatorMove (void)
+static void PM_SpectatorMove(void)
 {
 	float newspeed, currentspeed, addspeed, accelspeed, wishspeed;
 	float speed, drop, friction, control, fmove, smove;
 	vec3_t wishvel, wishdir;
 	int i;
 
-
 	// friction
-	speed = VectorLength (pmove.velocity);
-	if (speed < 1)
-	{
-		VectorClear (pmove.velocity);
+	speed = VectorLength(pmove.velocity);
+	if (speed < 1) {
+		VectorClear(pmove.velocity);
 	}
-	else
-	{
+	else {
 		friction = movevars.friction * 1.5; // extra friction
 		control = speed < movevars.stopspeed ? movevars.stopspeed : speed;
 		drop = control * friction * pm_frametime;
 
 		// scale the velocity
 		newspeed = speed - drop;
-		if (newspeed < 0)
+		if (newspeed < 0) {
 			newspeed = 0;
+		}
 		newspeed /= speed;
 
-		VectorScale (pmove.velocity, newspeed, pmove.velocity);
+		VectorScale(pmove.velocity, newspeed, pmove.velocity);
 	}
 
 	// accelerate
 	fmove = pmove.cmd.forwardmove;
 	smove = pmove.cmd.sidemove;
 
-	VectorNormalize (pm_forward);
-	VectorNormalize (pm_right);
+	VectorNormalize(pm_forward);
+	VectorNormalize(pm_right);
 
-	for (i = 0; i < 3; i++)
+	for (i = 0; i < 3; i++) {
 		wishvel[i] = pm_forward[i] * fmove + pm_right[i] * smove;
+	}
 	wishvel[2] += pmove.cmd.upmove;
 
-	VectorCopy (wishvel, wishdir);
+	VectorCopy(wishvel, wishdir);
 	wishspeed = VectorNormalize(wishdir);
 
 	// clamp to server defined max speed
-	if (wishspeed > movevars.spectatormaxspeed)
-	{
-		VectorScale (wishvel, movevars.spectatormaxspeed / wishspeed, wishvel);
+	if (wishspeed > movevars.spectatormaxspeed) {
+		VectorScale(wishvel, movevars.spectatormaxspeed / wishspeed, wishvel);
 		wishspeed = movevars.spectatormaxspeed;
 	}
 
@@ -811,95 +800,97 @@ static void PM_SpectatorMove (void)
 	addspeed = wishspeed - currentspeed;
 
 	// Buggy QW spectator mode, kept for compatibility
-	if (pmove.pm_type == PM_OLD_SPECTATOR)
-	{
-		if (addspeed <= 0)
+	if (pmove.pm_type == PM_OLD_SPECTATOR) {
+		if (addspeed <= 0) {
 			return;
+		}
 	}
 
-	if (addspeed > 0)
-	{
+	if (addspeed > 0) {
 		accelspeed = movevars.accelerate * pm_frametime * wishspeed;
 		accelspeed = min(accelspeed, addspeed);
 		VectorMA(pmove.velocity, accelspeed, wishdir, pmove.velocity);
 	}
 
 	// move
-	VectorMA (pmove.origin, pm_frametime, pmove.velocity, pmove.origin);
+	VectorMA(pmove.origin, pm_frametime, pmove.velocity, pmove.origin);
 }
 
 //Returns with origin, angles, and velocity modified in place.
 //Numtouch and touchindex[] will be set if any of the physents were contacted during the move.
-int PM_PlayerMove (void)
+int PM_PlayerMove(void)
 {
 	int blocked = 0;
+
+#ifndef SERVERONLY
+#ifdef EXPERIMENTAL_SHOW_ACCELERATION
+	if (flag_player_pmove) player_in_air = false;
+#endif
+#endif
 
 	pm_frametime = pmove.cmd.msec * 0.001;
 	pmove.numtouch = 0;
 
-	if (pmove.pm_type == PM_NONE || pmove.pm_type == PM_LOCK)
-	{
-		PM_CategorizePosition ();
+	if (pmove.pm_type == PM_NONE || pmove.pm_type == PM_LOCK) {
+		PM_CategorizePosition();
 		return 0;
 	}
 
 	// take angles directly from command
-	VectorCopy (pmove.cmd.angles, pmove.angles);
-	AngleVectors (pmove.angles, pm_forward, pm_right, NULL);
+	VectorCopy(pmove.cmd.angles, pmove.angles);
+	AngleVectors(pmove.angles, pm_forward, pm_right, NULL);
 
-	if (pmove.pm_type == PM_SPECTATOR || pmove.pm_type == PM_OLD_SPECTATOR)
-	{
-		PM_SpectatorMove ();
+	if (pmove.pm_type == PM_SPECTATOR || pmove.pm_type == PM_OLD_SPECTATOR) {
+		PM_SpectatorMove();
 		pmove.onground = false;
 		return 0;
 	}
 
-	PM_NudgePosition ();
+	PM_NudgePosition();
 
 	// set onground, watertype, and waterlevel
-	PM_CategorizePosition ();
+	PM_CategorizePosition();
 
 	if (pmove.waterlevel == 2 && pmove.pm_type != PM_FLY)
-		PM_CheckWaterJump ();
+		PM_CheckWaterJump();
 
 	if (pmove.velocity[2] < 0 || pmove.pm_type == PM_DEAD)
 		pmove.waterjumptime = 0;
 
-	if (pmove.waterjumptime)
-	{
+	if (pmove.waterjumptime) {
 		pmove.waterjumptime -= pm_frametime;
 		if (pmove.waterjumptime < 0)
 			pmove.waterjumptime = 0;
 	}
 
-	if (pmove.jump_msec)
-	{
+	if (pmove.jump_msec) {
 		pmove.jump_msec += pmove.cmd.msec;
 		if (pmove.jump_msec > 50)
 			pmove.jump_msec = 0;
 	}
 
-	PM_CheckJump ();
+	PM_CheckJump();
 
-	PM_Friction ();
+	PM_Friction();
 
 	if (pmove.waterlevel >= 2)
-		blocked = PM_WaterMove ();
+		blocked = PM_WaterMove();
 	else if (pmove.pm_type == PM_FLY)
-		blocked = PM_FlyMove ();
+		blocked = PM_FlyMove();
 	else
-		blocked = PM_AirMove ();
+		blocked = PM_AirMove();
 
 	// set onground, watertype, and waterlevel for final spot
-	PM_CategorizePosition ();
+	PM_CategorizePosition();
 
-	if (!movevars.pground)
-	{
+	if (!movevars.pground) {
 		// this is to make sure landing sound is not played twice
 		// and falling damage is calculated correctly
-		if (pmove.onground && pmove.velocity[2] < -300
-		        && DotProduct(pmove.velocity, groundplane.normal) < -0.1)
-			PM_ClipVelocity (pmove.velocity, groundplane.normal, pmove.velocity, 1);
+		if (pmove.onground && pmove.velocity[2] < -300) {
+			if (DotProduct(pmove.velocity, groundplane.normal) < -0.1) {
+				PM_ClipVelocity(pmove.velocity, groundplane.normal, pmove.velocity, 1);
+			}
+		}
 	}
 
 	return blocked;

--- a/src/pmove.h
+++ b/src/pmove.h
@@ -92,7 +92,7 @@ typedef struct {
 extern	movevars_t movevars;
 extern	playermove_t pmove;
 
-void PM_PlayerMove (void);
+int PM_PlayerMove (void);
 
 int PM_PointContents (vec3_t point);
 int PM_PointContents_AllBSPs (vec3_t p);

--- a/src/pmove.h
+++ b/src/pmove.h
@@ -24,27 +24,24 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #define	MAX_PHYSENTS 64 
 
-typedef struct
-{
+typedef struct {
 	vec3_t		origin;
 	cmodel_t	*model;		// only for bsp models
 	vec3_t		mins, maxs;	// only for non-bsp models
 	int			info;		// for client or server to identify
 } physent_t;
 
-typedef enum
-{
-	PM_NORMAL,			// normal ground movement
-	PM_OLD_SPECTATOR,	// fly, no clip to world (QW bug)
-	PM_SPECTATOR,		// fly, no clip to world
-	PM_DEAD,			// no acceleration
-	PM_FLY,				// fly, bump into walls
-	PM_NONE,			// can't move
-	PM_LOCK				// server controls origin and view angles
+typedef enum {
+	PM_NORMAL,              // normal ground movement
+	PM_OLD_SPECTATOR,       // fly, no clip to world (QW bug)
+	PM_SPECTATOR,           // fly, no clip to world
+	PM_DEAD,                // no acceleration
+	PM_FLY,                 // fly, bump into walls
+	PM_NONE,                // can't move
+	PM_LOCK                 // server controls origin and view angles
 } pmtype_t;
 
-typedef struct
-{
+typedef struct {
 	// player state
 	vec3_t		origin;
 	vec3_t		angles;
@@ -88,9 +85,8 @@ typedef struct {
 	qbool	pground; // NQ-style "onground" flag handling.
 } movevars_t;
 
-
-extern	movevars_t movevars;
-extern	playermove_t pmove;
+extern movevars_t movevars;
+extern playermove_t pmove;
 
 int PM_PlayerMove (void);
 

--- a/src/pmovetst.c
+++ b/src/pmovetst.c
@@ -19,7 +19,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 	
 */
 
+#ifdef SERVERONLY
 #include "qwsvdef.h"
+#else
+#include "quakedef.h"
+#include "pmove.h"
+#endif
 
 extern	vec3_t player_mins;
 extern	vec3_t player_maxs;
@@ -69,11 +74,11 @@ For waterjump test
 */
 int PM_PointContents_AllBSPs (vec3_t p)
 {
-	int i;
-	physent_t	*pe;
-	hull_t		*hull;
-	vec3_t		test;
-	int	result, final;
+	int         i;
+	physent_t   *pe;
+	hull_t      *hull;
+	vec3_t      test;
+	int         result, final;
 
 	final = CONTENTS_EMPTY;
 	for (i = 0; i < pmove.numphysent; i++)
@@ -102,33 +107,31 @@ Returns false if the given player position is not valid (in solid)
 */
 qbool PM_TestPlayerPosition (vec3_t pos)
 {
-	int			i;
-	physent_t	*pe;
-	vec3_t		mins, maxs, offset, test;
-	hull_t		*hull;
+	int       i;
+	physent_t *pe;
+	vec3_t    mins, maxs, offset, test;
+	hull_t    *hull;
 
-	for (i=0 ; i< pmove.numphysent; i++)
-	{
+	for (i = 0; i < pmove.numphysent; i++) {
 		pe = &pmove.physents[i];
 		// get the clipping hull
-		if (pe->model)
-		{
+		if (pe->model) {
 			hull = &pmove.physents[i].model->hulls[1];
-			VectorSubtract (hull->clip_mins, player_mins, offset);
-			VectorAdd (offset, pe->origin, offset);
+			VectorSubtract(hull->clip_mins, player_mins, offset);
+			VectorAdd(offset, pe->origin, offset);
 		}
-		else
-		{
-			VectorSubtract (pe->mins, player_maxs, mins);
-			VectorSubtract (pe->maxs, player_mins, maxs);
-			hull = CM_HullForBox (mins, maxs);
-			VectorCopy (pe->origin, offset);
+		else {
+			VectorSubtract(pe->mins, player_maxs, mins);
+			VectorSubtract(pe->maxs, player_mins, maxs);
+			hull = CM_HullForBox(mins, maxs);
+			VectorCopy(pe->origin, offset);
 		}
 
-		VectorSubtract (pos, offset, test);
+		VectorSubtract(pos, offset, test);
 
-		if (CM_HullPointContents (hull, hull->firstclipnode, test) == CONTENTS_SOLID)
+		if (CM_HullPointContents(hull, hull->firstclipnode, test) == CONTENTS_SOLID) {
 			return false;
+		}
 	}
 
 	return true;
@@ -141,13 +144,13 @@ PM_PlayerTrace
 */
 trace_t PM_PlayerTrace (vec3_t start, vec3_t end)
 {
-	trace_t		trace, total;
-	vec3_t		offset;
-	vec3_t		start_l, end_l;
-	hull_t		*hull;
-	int			i;
-	physent_t	*pe;
-	vec3_t		mins, maxs, tracemins, tracemaxs;
+	trace_t   trace, total;
+	vec3_t    offset;
+	vec3_t    start_l, end_l;
+	hull_t    *hull;
+	int       i;
+	physent_t *pe;
+	vec3_t    mins, maxs, tracemins, tracemaxs;
 
 	// fill in a default trace
 	memset (&total, 0, sizeof(trace_t));
@@ -157,54 +160,53 @@ trace_t PM_PlayerTrace (vec3_t start, vec3_t end)
 
 	PM_TraceBounds(start, end, tracemins, tracemaxs);
 
-	for (i=0; i< pmove.numphysent; i++)
-	{
+	for (i = 0; i < pmove.numphysent; i++) {
 		pe = &pmove.physents[i];
 
 		// get the clipping hull
-		if (pe->model)
-		{
+		if (pe->model) {
 			hull = &pmove.physents[i].model->hulls[1];
 
-			if (i > 0 && PM_CullTraceBox(tracemins, tracemaxs, pe->origin, pe->model->mins, pe->model->maxs, hull->clip_mins, hull->clip_maxs))
+			if (i > 0 && PM_CullTraceBox(tracemins, tracemaxs, pe->origin, pe->model->mins, pe->model->maxs, hull->clip_mins, hull->clip_maxs)) {
 				continue;
+			}
 
-			VectorSubtract (hull->clip_mins, player_mins, offset);
-			VectorAdd (offset, pe->origin, offset);
+			VectorSubtract(hull->clip_mins, player_mins, offset);
+			VectorAdd(offset, pe->origin, offset);
 		}
-		else
-		{
-			VectorSubtract (pe->mins, player_maxs, mins);
-			VectorSubtract (pe->maxs, player_mins, maxs);
+		else {
+			VectorSubtract(pe->mins, player_maxs, mins);
+			VectorSubtract(pe->maxs, player_mins, maxs);
 
-			if (PM_CullTraceBox(tracemins, tracemaxs, pe->origin, mins, maxs, vec3_origin, vec3_origin))
+			if (PM_CullTraceBox(tracemins, tracemaxs, pe->origin, mins, maxs, vec3_origin, vec3_origin)) {
 				continue;
+			}
 
-			hull = CM_HullForBox (mins, maxs);
-			VectorCopy (pe->origin, offset);
+			hull = CM_HullForBox(mins, maxs);
+			VectorCopy(pe->origin, offset);
 		}
 
-		VectorSubtract (start, offset, start_l);
-		VectorSubtract (end, offset, end_l);
+		VectorSubtract(start, offset, start_l);
+		VectorSubtract(end, offset, end_l);
 
-		// trace a line through the apropriate clipping hull
-		trace = CM_HullTrace (hull, start_l, end_l);
+		// trace a line through the appropriate clipping hull
+		trace = CM_HullTrace(hull, start_l, end_l);
 
 		// fix trace up by the offset
-		VectorAdd (trace.endpos, offset, trace.endpos);
+		VectorAdd(trace.endpos, offset, trace.endpos);
 
-		if (trace.allsolid)
+		if (trace.allsolid) {
 			trace.startsolid = true;
-		if (trace.startsolid)
+		}
+		if (trace.startsolid) {
 			trace.fraction = 0;
+		}
 
 		// did we clip the move?
-		if (trace.fraction < total.fraction)
-		{
+		if (trace.fraction < total.fraction) {
 			total = trace;
 			total.e.entnum = i;
 		}
-
 	}
 
 	return total;
@@ -229,32 +231,32 @@ trace_t PM_TraceLine (vec3_t start, vec3_t end)
 	total.e.entnum = -1;
 	VectorCopy (end, total.endpos);
 
-	for (i = 0; i < pmove.numphysent; i++)
-	{
+	for (i = 0; i < pmove.numphysent; i++) {
 		pe = &pmove.physents[i];
 		// get the clipping hull
-		hull = (pe->model) ? (&pmove.physents[i].model->hulls[0]) : (CM_HullForBox (pe->mins, pe->maxs));
+		hull = (pe->model) ? (&pmove.physents[i].model->hulls[0]) : (CM_HullForBox(pe->mins, pe->maxs));
 
 		// PM_HullForEntity (ent, mins, maxs, offset);
-		VectorCopy (pe->origin, offset);
+		VectorCopy(pe->origin, offset);
 
-		VectorSubtract (start, offset, start_l);
-		VectorSubtract (end, offset, end_l);
+		VectorSubtract(start, offset, start_l);
+		VectorSubtract(end, offset, end_l);
 
-		// trace a line through the apropriate clipping hull
-		trace = CM_HullTrace (hull, start_l, end_l);
+		// trace a line through the appropriate clipping hull
+		trace = CM_HullTrace(hull, start_l, end_l);
 
 		// fix trace up by the offset
-		VectorAdd (trace.endpos, offset, trace.endpos);
+		VectorAdd(trace.endpos, offset, trace.endpos);
 
-		if (trace.allsolid)
+		if (trace.allsolid) {
 			trace.startsolid = true;
-		if (trace.startsolid)
+		}
+		if (trace.startsolid) {
 			trace.fraction = 0;
+		}
 
 		// did we clip the move?
-		if (trace.fraction < total.fraction)
-		{
+		if (trace.fraction < total.fraction) {
 			total = trace;
 			total.e.entnum = i;
 		}

--- a/src/pr2.h
+++ b/src/pr2.h
@@ -76,10 +76,14 @@ void 		PR2_GameConsoleCommand(void);
 void		PR2_PausedTic(float duration);
 #define PR_PausedTic PR2_PausedTic
 
-char*		PR2_GetString(intptr_t);
-#define		PR_GetString PR2_GetString
-intptr_t	PR2_SetString(char*s);
-#define PR_SetString PR2_SetString
+char*		PR2_GetString(intptr_t reference);
+//#define		PR_GetString PR2_GetString
+char*       PR2_GetEntityString(string_t reference);
+#define     PR_GetEntityString PR2_GetEntityString
+void        PR2_SetEntityString(edict_t* ed, string_t* target, char* value);
+void        PR2_SetGlobalString(string_t* target, char* value);
+#define     PR_SetEntityString(entity, address, value) PR2_SetEntityString(entity, &address, value)
+#define     PR_SetGlobalString(address, value) PR2_SetGlobalString(&address, value)
 void		PR2_RunError(char *error, ...);
 eval_t*		PR2_GetEdictFieldValue(edict_t *ed, char *field);
 #define PR_GetEdictFieldValue PR2_GetEdictFieldValue
@@ -87,5 +91,7 @@ int			ED2_FindFieldOffset(char *field);
 #define ED_FindFieldOffset ED2_FindFieldOffset
 void 		PR2_InitProg();
 #define PR_InitProg PR2_InitProg
+void        PR2_ClearEdict(edict_t* e);
+#define PR_ClearEdict PR2_ClearEdict
 
 #endif /* !__PR2_H__ */

--- a/src/pr2.h
+++ b/src/pr2.h
@@ -38,7 +38,7 @@ void		PR2_UnLoadProgs();
 #define PR_UnLoadProgs PR2_UnLoadProgs
 void		PR2_LoadProgs();
 #define PR_LoadProgs PR2_LoadProgs
-void		PR2_GameStartFrame();
+void		PR2_GameStartFrame(qbool isBotFrame);
 #define PR_GameStartFrame PR2_GameStartFrame
 void		PR2_LoadEnts(char *data);
 #define PR_LoadEnts PR2_LoadEnts

--- a/src/pr2.h
+++ b/src/pr2.h
@@ -32,11 +32,11 @@ extern cvar_t sv_progtype;
 extern vm_t* sv_vm;
 
 
-void		PR2_Init();
+void		PR2_Init(void);
 #define PR_Init PR2_Init
-void		PR2_UnLoadProgs();
+void		PR2_UnLoadProgs(void);
 #define PR_UnLoadProgs PR2_UnLoadProgs
-void		PR2_LoadProgs();
+void		PR2_LoadProgs(void);
 #define PR_LoadProgs PR2_LoadProgs
 void		PR2_GameStartFrame(qbool isBotFrame);
 #define PR_GameStartFrame PR2_GameStartFrame
@@ -52,15 +52,15 @@ void		PR2_GameClientPreThink(int spec);
 #define PR_GameClientPreThink PR2_GameClientPreThink
 void		PR2_GameClientPostThink(int spec);
 #define PR_GameClientPostThink PR2_GameClientPostThink
-qbool		PR2_ClientCmd();
+qbool		PR2_ClientCmd(void);
 #define PR_ClientCmd PR2_ClientCmd
-void		PR2_ClientKill();
+void		PR2_ClientKill(void);
 #define PR_ClientKill PR2_ClientKill
 qbool		PR2_ClientSay(int isTeamSay, char *message);
 #define PR_ClientSay PR2_ClientSay
-void		PR2_GameSetNewParms();
+void		PR2_GameSetNewParms(void);
 #define PR_GameSetNewParms PR2_GameSetNewParms
-void		PR2_GameSetChangeParms();
+void		PR2_GameSetChangeParms(void);
 #define PR_GameSetChangeParms PR2_GameSetChangeParms
 void		PR2_EdictTouch(func_t f);
 #define PR_EdictTouch PR2_EdictTouch
@@ -68,9 +68,9 @@ void		PR2_EdictThink(func_t f);
 #define PR_EdictThink PR2_EdictThink
 void		PR2_EdictBlocked(func_t f);
 #define PR_EdictBlocked PR2_EdictBlocked
-qbool 		PR2_UserInfoChanged();
+qbool 		PR2_UserInfoChanged(void);
 #define PR_UserInfoChanged PR2_UserInfoChanged
-void 		PR2_GameShutDown();
+void 		PR2_GameShutDown(void);
 #define PR_GameShutDown PR2_GameShutDown
 void 		PR2_GameConsoleCommand(void);
 void		PR2_PausedTic(float duration);
@@ -89,7 +89,7 @@ eval_t*		PR2_GetEdictFieldValue(edict_t *ed, char *field);
 #define PR_GetEdictFieldValue PR2_GetEdictFieldValue
 int			ED2_FindFieldOffset(char *field);
 #define ED_FindFieldOffset ED2_FindFieldOffset
-void 		PR2_InitProg();
+void 		PR2_InitProg(void);
 #define PR_InitProg PR2_InitProg
 void        PR2_ClearEdict(edict_t* e);
 #define PR_ClearEdict PR2_ClearEdict

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -162,7 +162,7 @@ void PR2_LoadEnts(char *data)
 //===========================================================================
 // GameStartFrame
 //===========================================================================
-void PR2_GameStartFrame()
+void PR2_GameStartFrame(void)
 {
 	if (sv_vm)
 		VM_Call(sv_vm, GAME_START_FRAME, (int) (sv.time * 1000), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -228,7 +228,7 @@ void PR2_GameClientPostThink(int spec)
 //===========================================================================
 // ClientCmd return false on unknown command
 //===========================================================================
-qbool PR2_ClientCmd()
+qbool PR2_ClientCmd(void)
 {
 	if (sv_vm)
 		return VM_Call(sv_vm, GAME_CLIENT_COMMAND, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -239,7 +239,7 @@ qbool PR2_ClientCmd()
 //===========================================================================
 // ClientKill
 //===========================================================================
-void PR2_ClientKill()
+void PR2_ClientKill(void)
 {
 	if (sv_vm)
 		PR2_ClientCmd(); // PR2 have some universal way for command execution unlike QC based mods.
@@ -266,7 +266,7 @@ qbool PR2_ClientSay(int isTeamSay, char *message)
 //===========================================================================
 // GameSetNewParms
 //===========================================================================
-void PR2_GameSetNewParms()
+void PR2_GameSetNewParms(void)
 {
 	if (sv_vm)
 		VM_Call(sv_vm, GAME_SETNEWPARMS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -277,7 +277,7 @@ void PR2_GameSetNewParms()
 //===========================================================================
 // GameSetNewParms
 //===========================================================================
-void PR2_GameSetChangeParms()
+void PR2_GameSetChangeParms(void)
 {
 	if (sv_vm)
 		VM_Call(sv_vm, GAME_SETCHANGEPARMS, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -323,7 +323,7 @@ void PR2_EdictBlocked(func_t f)
 //===========================================================================
 // UserInfoChanged
 //===========================================================================
-qbool PR2_UserInfoChanged()
+qbool PR2_UserInfoChanged(void)
 {
 	if (sv_vm)
 		return VM_Call(sv_vm, GAME_CLIENT_USERINFO_CHANGED, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -334,7 +334,7 @@ qbool PR2_UserInfoChanged()
 //===========================================================================
 // GameShutDown
 //===========================================================================
-void PR2_GameShutDown()
+void PR2_GameShutDown(void)
 {
 	if (sv_vm)
 		VM_Call(sv_vm, GAME_SHUTDOWN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -345,7 +345,7 @@ void PR2_GameShutDown()
 //===========================================================================
 // UnLoadProgs
 //===========================================================================
-void PR2_UnLoadProgs()
+void PR2_UnLoadProgs(void)
 {
 	if (sv_vm)
 	{
@@ -361,7 +361,7 @@ void PR2_UnLoadProgs()
 //===========================================================================
 // LoadProgs
 //===========================================================================
-void PR2_LoadProgs()
+void PR2_LoadProgs(void)
 {
 	sv_vm = (vm_t *) VM_Load(sv_vm, (vm_type_t) (int) sv_progtype.value, sv_progsname.string, sv_syscall, sv_sys_callex);
 

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -162,12 +162,12 @@ void PR2_LoadEnts(char *data)
 //===========================================================================
 // GameStartFrame
 //===========================================================================
-void PR2_GameStartFrame(void)
+void PR2_GameStartFrame(qbool isBotFrame)
 {
 	if (sv_vm)
-		VM_Call(sv_vm, GAME_START_FRAME, (int) (sv.time * 1000), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+		VM_Call(sv_vm, GAME_START_FRAME, (int) (sv.time * 1000), isBotFrame, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 	else
-		PR1_GameStartFrame();
+		PR1_GameStartFrame(isBotFrame);
 }
 
 //===========================================================================

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -24,9 +24,17 @@
 
 #include "qwsvdef.h"
 
+qbool PR2_IsValidWriteAddress(register qvm_t * qvm, intptr_t address);
+qbool PR2_IsValidReadAddress(register qvm_t * qvm, intptr_t address);
+
 gameData_t *gamedata;
 
-cvar_t	sv_progtype = {"sv_progtype","0"};	// bound the size of the
+// 0 = pr1 (qwprogs.dat etc), 1 = native (.so/.dll), 2 = q3vm (.qvm)
+cvar_t sv_progtype = { "sv_progtype","0" };
+
+// 0 = standard, 1 = pr2 mods set string_t fields as byte offsets to location of actual strings
+cvar_t sv_pr2references = {"sv_pr2references", "0"};
+
 #ifdef QVM_PROFILE
 extern cvar_t sv_enableprofile;
 #endif
@@ -42,6 +50,7 @@ void PR2_Init(void)
 	int usedll;
 	Cvar_Register(&sv_progtype);
 	Cvar_Register(&sv_progsname);
+	Cvar_Register(&sv_pr2references);
 #ifdef WITH_NQPROGS
 	Cvar_Register(&sv_forcenqprogs);
 #endif
@@ -70,7 +79,7 @@ void PR2_Init(void)
 }
 
 //===========================================================================
-// PR2_GetString
+// PR2_GetString: only called to get direct addresses now
 //===========================================================================
 char *PR2_GetString(intptr_t num)
 {
@@ -85,21 +94,89 @@ char *PR2_GetString(intptr_t num)
 		return PR1_GetString(num);
 
 	case VM_NATIVE:
-		if (num)
-			return (char *) num;
-		else
+		if (num) {
+			return (char *)num;
+		}
+		else {
 			return "";
+		}
+
+	case VM_BYTECODE:
+		if (!num) {
+			return "";
+		}
+		qvm = (qvm_t*)(sv_vm->hInst);
+		if (! PR2_IsValidReadAddress(qvm, (intptr_t)qvm->ds + num)) {
+			Con_DPrintf("PR2_GetString error off %8x/%8x\n", num, qvm->len_ds );
+			return "";
+		}
+		return (char *) (qvm->ds + num);
+	}
+
+	return NULL;
+}
+
+intptr_t PR2_EntityStringLocation(string_t offset, int max_size)
+{
+	if (offset > 0 && offset < pr_edict_size * sv.max_edicts - max_size) {
+		return ((intptr_t)sv.edicts + offset);
+	}
+
+	return 0;
+}
+
+intptr_t PR2_GlobalStringLocation(string_t offset)
+{
+	// FIXME: the mod has allocated this memory, don't have max size
+	if (offset > 0) {
+		return ((intptr_t)pr_global_struct + offset);
+	}
+
+	return 0;
+}
+
+char *PR2_GetEntityString(string_t num)
+{
+	qvm_t *qvm;
+
+	if(!sv_vm)
+		return PR1_GetString(num);
+
+	switch (sv_vm->type)
+	{
+	case VM_NONE:
+		return PR1_GetString(num);
+
+	case VM_NATIVE:
+		if (num) {
+			char** location = (char**)PR2_EntityStringLocation(num, sizeof(char*));
+
+			if (location && *location) {
+				return *location;
+			}
+		}
+		return "";
 
 	case VM_BYTECODE:
 		if (!num)
 			return "";
 		qvm = (qvm_t*)(sv_vm->hInst);
-		if ( num & ( ~qvm->ds_mask) )
-		{
-			Con_DPrintf("PR2_GetString error off %8x/%8x\n", num, qvm->len_ds );
-			return "";
+		if (sv_vm->pr2_references) {
+			num = *(string_t*)PR2_EntityStringLocation(num, sizeof(string_t));
+
+			if (!PR2_IsValidReadAddress(qvm, (intptr_t)qvm->ds + num)) {
+				Con_DPrintf("PR2_GetEntityString error off %8x/%8x\n", num, qvm->len_ds);
+				return "";
+			}
+
+			if (num) {
+				return (char *) (qvm->ds+ num);
+			}
 		}
-		return (char *) (qvm->ds+ num);
+		else if (PR2_IsValidReadAddress(qvm, (intptr_t)qvm->ds + num)) {
+			return (char *) (qvm->ds+ num);
+		}
+		return "";
 	}
 
 	return NULL;
@@ -109,32 +186,91 @@ char *PR2_GetString(intptr_t num)
 // PR2_SetString
 // FIXME for VM
 //===========================================================================
-intptr_t PR2_SetString(char *s)
+void PR2_SetEntityString(edict_t* ed, string_t* target, char* s)
 {
 	qvm_t *qvm;
 	intptr_t off;
-	if(!sv_vm)
-		return PR1_SetString(s);
+	if (!sv_vm) {
+		PR1_SetString(target, s);
+		return;
+	}
 
 	switch (sv_vm->type)
 	{
 	case VM_NONE:
-		return PR1_SetString(s);
+		PR1_SetString(target, s);
+		return;
 
 	case VM_NATIVE:
-		return (intptr_t) s;
+		{
+			char** location = (char**)PR2_EntityStringLocation(*target, sizeof(char*));
+
+			if (location) {
+				*location = s;
+			}
+		}
+		return;
 
 	case VM_BYTECODE:
 		qvm = (qvm_t*)(sv_vm->hInst);
 		off = (byte*)s - qvm->ds;
-		if (off &(~qvm->ds_mask))
-			return 0;
 
-		return off;
-		break;
+		if (sv_vm->pr2_references) {
+			string_t* location = (string_t*)PR2_EntityStringLocation(*target, sizeof(string_t));
+
+			if (location && PR2_IsValidWriteAddress(qvm, (intptr_t)location)) {
+				*location = off;
+			}
+		}
+		else if (PR2_IsValidWriteAddress(qvm, (intptr_t)target)) {
+			*target = off;
+		}
+		return;
 	}
 
-	return 0;
+	*target = 0;
+}
+
+void PR2_SetGlobalString(string_t* target, char* s)
+{
+	qvm_t *qvm;
+	intptr_t off;
+	if (!sv_vm) {
+		PR1_SetString(target, s);
+		return;
+	}
+
+	switch (sv_vm->type)
+	{
+	case VM_NONE:
+		PR1_SetString(target, s);
+		return;
+
+	case VM_NATIVE:
+	{
+		char** location = (char**)PR2_GlobalStringLocation(*target);
+		if (location) {
+			*location = s;
+		}
+	}
+	return;
+
+	case VM_BYTECODE:
+		qvm = (qvm_t*)(sv_vm->hInst);
+		off = (byte*)s - qvm->ds;
+		if (sv_vm->pr2_references) {
+			string_t* location = (string_t*)PR2_GlobalStringLocation(*target);
+			if (location && PR2_IsValidWriteAddress(qvm, (intptr_t)location)) {
+				*location = off;
+			}
+		}
+		else if (PR2_IsValidWriteAddress(qvm, (intptr_t)target)) {
+			*target = off;
+		}
+		return;
+	}
+
+	*target = 0;
 }
 
 /*
@@ -419,6 +555,16 @@ void PR2_PausedTic(float duration)
 		VM_Call(sv_vm, GAME_PAUSED_TIC, duration*1000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 	else
 		PR1_PausedTic(duration);
+}
+
+void PR2_ClearEdict(edict_t* e)
+{
+	if (sv_vm && sv_vm->pr2_references && (sv_vm->type == VM_NATIVE || sv_vm->type == VM_BYTECODE)) {
+		int old_self = pr_global_struct->self;
+		pr_global_struct->self = EDICT_TO_PROG(e);
+		VM_Call(sv_vm, GAME_CLEAR_EDICT, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+		pr_global_struct->self = old_self;
+	}
 }
 
 #endif /* USE_PR2 */

--- a/src/pr2_exec.c
+++ b/src/pr2_exec.c
@@ -247,13 +247,13 @@ void PR2_SetGlobalString(string_t* target, char* s)
 		return;
 
 	case VM_NATIVE:
-	{
-		char** location = (char**)PR2_GlobalStringLocation(*target);
-		if (location) {
-			*location = s;
+		{
+			char** location = (char**)PR2_GlobalStringLocation(*target);
+			if (location) {
+				*location = s;
+			}
 		}
-	}
-	return;
+		return;
 
 	case VM_BYTECODE:
 		qvm = (qvm_t*)(sv_vm->hInst);
@@ -300,10 +300,14 @@ void PR2_LoadEnts(char *data)
 //===========================================================================
 void PR2_GameStartFrame(qbool isBotFrame)
 {
+	if (isBotFrame && (!sv_vm || sv_vm->type == VM_NONE || !gamedata || gamedata->APIversion < 15)) {
+		return;
+	}
+
 	if (sv_vm)
 		VM_Call(sv_vm, GAME_START_FRAME, (int) (sv.time * 1000), isBotFrame, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 	else
-		PR1_GameStartFrame(isBotFrame);
+		PR1_GameStartFrame();
 }
 
 //===========================================================================

--- a/src/pr2_vm.c
+++ b/src/pr2_vm.c
@@ -71,7 +71,7 @@ profile_t* ProfileEnterFunction(int adress)
 symbols_t* QVM_FindName( qvm_t * qvm, int off);
 #endif
 
-void PR2_Profile_f()
+void PR2_Profile_f(void)
 {
 #ifdef QVM_PROFILE
 	profile_t	*f, *best;

--- a/src/pr2_vm.c
+++ b/src/pr2_vm.c
@@ -48,6 +48,47 @@ profile_t;
 profile_t profile_funcs[MAX_PROFILE_FUNCS];
 int num_profile_func;
 
+qbool PR2_IsValidReadAddress(register qvm_t * qvm, intptr_t address)
+{
+	if (address >= (intptr_t)&sv && address < ((intptr_t)&sv) + sizeof(sv) - 4) {
+		return true;
+	}
+	if (address >= (intptr_t)&svs.clients && address < ((intptr_t)&svs.clients) + sizeof(svs.clients) - 4) {
+		return true;
+	}
+	if (address == (intptr_t)VersionStringFull()) {
+		return true;
+	}
+
+	return (address >= (intptr_t)qvm->ds && address < (intptr_t)qvm->ds + qvm->len_ds);
+}
+
+qbool PR2_IsValidWriteAddress(register qvm_t * qvm, intptr_t address)
+{
+	if (address >= (intptr_t)&sv && address < ((intptr_t)&sv) + sizeof(sv) - 4) {
+		return true;
+	}
+	if (address >= (intptr_t)&svs.clients && address < ((intptr_t)&svs.clients) + sizeof(svs.clients) - 4) {
+		return true;
+	}
+
+	return (address >= (intptr_t)qvm->ds && address < (intptr_t)qvm->ds + qvm->len_ds);
+}
+
+#define OLD_VM_POINTER(base,mask,x) ((void*)((char *)base+((x)&mask)))
+
+void* VM_POINTER(byte* base, uintptr_t mask, intptr_t offset)
+{
+	intptr_t address = (intptr_t) base + offset;
+	qvm_t* qvm = (qvm_t*) sv_vm->hInst;
+
+	if (PR2_IsValidWriteAddress(qvm, (intptr_t)base + offset)) {
+		return (void*)((intptr_t)base + offset);
+	}
+
+	return OLD_VM_POINTER(base, mask, offset);
+}
+
 profile_t* ProfileEnterFunction(int adress)
 {
 	int i;
@@ -871,7 +912,7 @@ int QVM_Exec( register qvm_t * qvm, int command, int arg0, int arg1, int arg2, i
 			ivar = opStack[qvm->SP]._int;
 
 #ifdef QVM_DATA_PROTECTION
-			if ( ivar & (~qvm->ds_mask) )
+			if (!PR2_IsValidReadAddress(qvm, (intptr_t)qvm->ds + ivar))
 				QVM_RunError( qvm, "data load 1 out of range %8x\n", ivar );
 			opStack[qvm->SP]._int = *( char * ) ( qvm->ds + ivar );
 #else
@@ -882,7 +923,7 @@ int QVM_Exec( register qvm_t * qvm, int command, int arg0, int arg1, int arg2, i
 		case OP_LOAD2:
 			ivar = opStack[qvm->SP]._int;
 #ifdef QVM_DATA_PROTECTION
-			if ( ivar & (~qvm->ds_mask) )
+			if (!PR2_IsValidReadAddress(qvm, (intptr_t)qvm->ds + ivar))
 				QVM_RunError( qvm, "data load 2 out of range %8x\n", ivar );
 			opStack[qvm->SP]._int = *( short * ) ( qvm->ds + ivar );
 #else
@@ -893,7 +934,7 @@ int QVM_Exec( register qvm_t * qvm, int command, int arg0, int arg1, int arg2, i
 		case OP_LOAD4:
 			ivar = opStack[qvm->SP]._int;
 #ifdef QVM_DATA_PROTECTION
-			if ( ivar & (~qvm->ds_mask) )
+			if (!PR2_IsValidReadAddress(qvm, (intptr_t)qvm->ds + ivar))
 				QVM_RunError( qvm, "data load 4 out of range %8x\n", ivar );
 			opStack[qvm->SP]._int = *( int * ) ( qvm->ds + ivar );
 #else
@@ -903,7 +944,7 @@ int QVM_Exec( register qvm_t * qvm, int command, int arg0, int arg1, int arg2, i
 		case OP_STORE1:
 			ivar = opStack[qvm->SP - 1]._int;
 #ifdef QVM_DATA_PROTECTION
-			if ( ivar & (~qvm->ds_mask) )
+			if (!PR2_IsValidWriteAddress(qvm, (intptr_t)qvm->ds + ivar))
 				QVM_RunError( qvm, "data store 1 out of range %8x\n", ivar );
 			*( char * ) ( qvm->ds + ivar ) = opStack[qvm->SP]._int & 0xff;
 #else
@@ -914,7 +955,7 @@ int QVM_Exec( register qvm_t * qvm, int command, int arg0, int arg1, int arg2, i
 		case OP_STORE2:
 			ivar = opStack[qvm->SP - 1]._int;
 #ifdef QVM_DATA_PROTECTION
-			if ( ivar & (~qvm->ds_mask) )
+			if (!PR2_IsValidWriteAddress(qvm, (intptr_t)qvm->ds + ivar))
 				QVM_RunError( qvm, "data store 2 out of range %8x\n", ivar );
 			*( short * ) ( qvm->ds + ivar ) = opStack[qvm->SP]._int & 0xffff;
 #else
@@ -926,7 +967,7 @@ int QVM_Exec( register qvm_t * qvm, int command, int arg0, int arg1, int arg2, i
 		case OP_STORE4:
 			ivar = opStack[qvm->SP - 1]._int;
 #ifdef QVM_DATA_PROTECTION
-			if ( ivar & (~qvm->ds_mask) )
+			if (!PR2_IsValidWriteAddress(qvm, (intptr_t)qvm->ds + ivar))
 				QVM_RunError( qvm, "data store 4 out of range %8x\n", ivar );
 			*( int * ) ( qvm->ds + ivar ) = opStack[qvm->SP]._int;
 #else
@@ -938,7 +979,7 @@ int QVM_Exec( register qvm_t * qvm, int command, int arg0, int arg1, int arg2, i
 		case OP_ARG:
 			ivar = qvm->LP + op.parm._int;
 #ifdef QVM_DATA_PROTECTION
-			if ( ivar & (~qvm->ds_mask) )
+			if (!PR2_IsValidWriteAddress(qvm, (intptr_t)qvm->ds + ivar))
 				QVM_RunError( qvm, "arg out of range %8x\n", ivar );
 			*( int * ) ( qvm->ds + ivar ) = opStack[qvm->SP--]._int;
 #else
@@ -953,10 +994,10 @@ int QVM_Exec( register qvm_t * qvm, int command, int arg0, int arg1, int arg2, i
 				off2 = opStack[qvm->SP]._int;
 				len = op.parm._int;
 #ifdef QVM_DATA_PROTECTION
-				if ( (off1 & (~qvm->ds_mask) ) || (off2 & (~qvm->ds_mask) )
-				        || ((off1 + len) & (~qvm->ds_mask) )
-				        || ((off2 + len) & (~qvm->ds_mask) ))
-					QVM_RunError( qvm, "block copy out of range %8x\n", ivar );
+				if (!PR2_IsValidWriteAddress(qvm, (intptr_t)qvm->ds + off1) || !PR2_IsValidWriteAddress(qvm, (intptr_t)qvm->ds + off1 + len) ||
+					!PR2_IsValidReadAddress(qvm, (intptr_t)qvm->ds + off2) || !PR2_IsValidReadAddress(qvm, (intptr_t)qvm->ds + off2 + len)) {
+					QVM_RunError(qvm, "block copy out of range %8x\n", ivar);
+				}
 				memmove( qvm->ds + off1, qvm->ds + off2, len );
 #else
 				memmove( qvm->ds + (off1 & qvm->ds_mask), qvm->ds + (off2 & qvm->ds_mask), len );

--- a/src/pr2_vm.c
+++ b/src/pr2_vm.c
@@ -82,8 +82,8 @@ void* VM_POINTER(byte* base, uintptr_t mask, intptr_t offset)
 	intptr_t address = (intptr_t) base + offset;
 	qvm_t* qvm = (qvm_t*) sv_vm->hInst;
 
-	if (PR2_IsValidWriteAddress(qvm, (intptr_t)base + offset)) {
-		return (void*)((intptr_t)base + offset);
+	if (PR2_IsValidWriteAddress(qvm, address)) {
+		return (void*)address;
 	}
 
 	return OLD_VM_POINTER(base, mask, offset);

--- a/src/pr2_vm.h
+++ b/src/pr2_vm.h
@@ -45,9 +45,9 @@
 
 typedef union pr2val_s
 {
-	string_t	string;
-	float		_float;
-	intptr_t	_int;
+	string_t    string;
+	float       _float;
+	intptr_t    _int;
 } pr2val_t;	
 
 typedef intptr_t (EXPORT_FN *sys_call_t) (intptr_t arg, ...);

--- a/src/pr2_vm.h
+++ b/src/pr2_vm.h
@@ -36,19 +36,23 @@
 #define OPSTACKSIZE		0x100
 #define MAX_PROC_CALL	100
 #define MAX_vmMain_Call	100
-#define MAX_CYCLES		100000
+#define MAX_CYCLES		3000000
 
 // this gives gcc warnings unfortunatelly
 //#define VM_POINTER(base,mask,x)		((x)?(void*)((char *)base+((x)&mask)):NULL)
-#define VM_POINTER(base,mask,x)			((void*)((char *)base+((x)&mask)))
+
+// #define VM_POINTER(base,mask,x)			((void*)((char *)base+((x)&mask)))
+void* VM_POINTER(byte* base, uintptr_t mask, intptr_t offset);
+
+// meag: can leave this right now only because it is only used to return pointers to edicts
 #define POINTER_TO_VM(base,mask,x)		((x)?(intptr_t)((char *)(x) - (char*)base)&mask:0)
 
 typedef union pr2val_s
 {
-	string_t    string;
-	float       _float;
-	intptr_t    _int;
-} pr2val_t;	
+	stringptr_t  string;
+	float        _float;
+	intptr_t     _int;
+} pr2val_t;
 
 typedef intptr_t (EXPORT_FN *sys_call_t) (intptr_t arg, ...);
 typedef int (*sys_callex_t) (byte *data, unsigned int mask, int fn,  pr2val_t* arg);
@@ -73,6 +77,9 @@ typedef struct vm_s {
 	intptr_t (*vmMain) (int command, int arg0, int arg1, int arg2, int arg3,
 		int arg4, int arg5, int arg6, int arg7, int arg8, int arg9,
 		int arg10, int arg11);
+
+	// whether or not pr2 references should be enabled (set on GAME_INIT)
+	qbool pr2_references;
 } vm_t ;
 
 typedef enum

--- a/src/pr_cmds.c
+++ b/src/pr_cmds.c
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "qwsvdef.h"
 
 #define	RETURN_EDICT(e) (((int *)pr_globals)[OFS_RETURN] = EDICT_TO_PROG(e))
-#define	RETURN_STRING(s) (((int *)pr_globals)[OFS_RETURN] = PR1_SetString(s))
+#define	RETURN_STRING(s) (PR1_SetString(&((int *)pr_globals)[OFS_RETURN], s))
 
 /*
 ===============================================================================
@@ -983,7 +983,7 @@ void PF_substr (void)
 
 	if (start >= l || !len || !*s)
 	{
-		G_INT(OFS_RETURN) = PR_SetTmpString("");
+		PR_SetTmpString(&G_INT(OFS_RETURN), "");
 		return;
 	}
 
@@ -995,7 +995,7 @@ void PF_substr (void)
 
 	strlcpy(pr_string_temp, s, len + 1);
 
-	G_INT(OFS_RETURN) = PR1_SetString(pr_string_temp);
+	PR1_SetString(&G_INT(OFS_RETURN), pr_string_temp);
 
 	PF_SetTempString();
 }
@@ -1011,7 +1011,7 @@ string strcat(string str1, string str2)
 void PF_strcat (void)
 {
 	strlcpy(pr_string_temp, PF_VarString(0), MAX_PR_STRING_SIZE);
-	G_INT(OFS_RETURN) = PR1_SetString(pr_string_temp);
+	PR1_SetString(&G_INT(OFS_RETURN), pr_string_temp);
 
 	PF_SetTempString();
 }
@@ -1127,7 +1127,7 @@ void PF_calltimeofday (void)
 		G_FLOAT(OFS_PARM3) = (float)date.day;
 		G_FLOAT(OFS_PARM4) = (float)date.mon;
 		G_FLOAT(OFS_PARM5) = (float)date.year;
-		G_INT(OFS_PARM6) = PR_SetTmpString(date.str);
+		PR_SetTmpString(&G_INT(OFS_PARM6), date.str);
 
 		PR_ExecuteProgram(f);
 	}
@@ -1259,7 +1259,7 @@ void PF_ftos (void)
 		snprintf (pr_string_temp, MAX_PR_STRING_SIZE, "%d",(int)v);
 	else
 		snprintf (pr_string_temp, MAX_PR_STRING_SIZE, "%5.1f",v);
-	G_INT(OFS_RETURN) = PR1_SetString(pr_string_temp);
+	PR1_SetString(&G_INT(OFS_RETURN), pr_string_temp);
 	PF_SetTempString();
 }
 
@@ -1273,7 +1273,7 @@ void PF_fabs (void)
 void PF_vtos (void)
 {
 	snprintf (pr_string_temp, MAX_PR_STRING_SIZE, "'%5.1f %5.1f %5.1f'", G_VECTOR(OFS_PARM0)[0], G_VECTOR(OFS_PARM0)[1], G_VECTOR(OFS_PARM0)[2]);
-	G_INT(OFS_RETURN) = PR1_SetString(pr_string_temp);
+	PR1_SetString(&G_INT(OFS_RETURN), pr_string_temp);
 
 	PF_SetTempString();
 }
@@ -2214,7 +2214,7 @@ void PF_makestatic (void)
 	s = &sv.static_entities[sv.static_entity_count];
 	memset(s, 0, sizeof(sv.static_entities[0]));
 	s->number = sv.static_entity_count + 1;
-	s->modelindex = SV_ModelIndex(PR_GetString(ent->v.model));
+	s->modelindex = SV_ModelIndex(PR_GetEntityString(ent->v.model));
 	if (!s->modelindex) {
 		ED_Free (ent);
 		return;

--- a/src/pr_cmds.c
+++ b/src/pr_cmds.c
@@ -1136,7 +1136,7 @@ void PF_calltimeofday (void)
 /*
 =================
 PF_cvar
- 
+
 float cvar (string)
 =================
 */
@@ -1215,8 +1215,8 @@ static void PF_findradius (void)
 		maxs[i] = org[i] + rad + 1;
 	}
 
-	numtouch = SV_AreaEdicts (mins, maxs, touchlist, MAX_EDICTS, AREA_SOLID);
-	numtouch += SV_AreaEdicts (mins, maxs, &touchlist[numtouch], MAX_EDICTS - numtouch, AREA_TRIGGERS);
+	numtouch = SV_AreaEdicts (mins, maxs, touchlist, sv.max_edicts, AREA_SOLID);
+	numtouch += SV_AreaEdicts (mins, maxs, &touchlist[numtouch], sv.max_edicts - numtouch, AREA_TRIGGERS);
 
 	chain = (edict_t *)sv.edicts;
 
@@ -2202,27 +2202,29 @@ int SV_ModelIndex (char *name);
 
 void PF_makestatic (void)
 {
+	entity_state_t* s;
 	edict_t	*ent;
-	int		i;
 
 	ent = G_EDICT(OFS_PARM0);
-	//bliP: for maps with null models which crash clients (nmtrees.bsp) ->
-	if (!SV_ModelIndex(PR1_GetString(ent->v.model)))
+	if (sv.static_entity_count >= sizeof(sv.static_entities) / sizeof(sv.static_entities[0])) {
+		ED_Free (ent);
 		return;
-	//<-
-
-	MSG_WriteByte (&sv.signon,svc_spawnstatic);
-
-	MSG_WriteByte (&sv.signon, SV_ModelIndex(PR1_GetString(ent->v.model)));
-
-	MSG_WriteByte (&sv.signon, ent->v.frame);
-	MSG_WriteByte (&sv.signon, ent->v.colormap);
-	MSG_WriteByte (&sv.signon, ent->v.skin);
-	for (i=0 ; i<3 ; i++)
-	{
-		MSG_WriteCoord(&sv.signon, ent->v.origin[i]);
-		MSG_WriteAngle(&sv.signon, ent->v.angles[i]);
 	}
+
+	s = &sv.static_entities[sv.static_entity_count];
+	memset(s, 0, sizeof(sv.static_entities[0]));
+	s->number = sv.static_entity_count + 1;
+	s->modelindex = SV_ModelIndex(PR_GetString(ent->v.model));
+	if (!s->modelindex) {
+		ED_Free (ent);
+		return;
+	}
+	s->frame = ent->v.frame;
+	s->colormap = ent->v.colormap;
+	s->skinnum = ent->v.skin;
+	VectorCopy(ent->v.origin, s->origin);
+	VectorCopy(ent->v.angles, s->angles);
+	++sv.static_entity_count;
 
 	// throw the entity away now
 	ED_Free (ent);

--- a/src/pr_comp.h
+++ b/src/pr_comp.h
@@ -23,8 +23,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // this file is shared by quake and qcc
 
-typedef intptr_t func_t;
-typedef intptr_t string_t;
+typedef int func_t;
+typedef int string_t;
+typedef intptr_t stringptr_t;
 
 typedef enum {ev_void, ev_string, ev_float, ev_vector, ev_entity, ev_field, ev_function, ev_pointer} etype_t;
 

--- a/src/pr_edict.c
+++ b/src/pr_edict.c
@@ -94,6 +94,7 @@ void ED_ClearEdict (edict_t *e)
 	memset(&e->v, 0, pr_edict_size - sizeof(edict_t) + sizeof(entvars_t));
 	e->e->lastruntime = 0;
 	e->e->free = false;
+	PR_ClearEdict(e);
 }
 
 /*
@@ -806,7 +807,7 @@ qbool ED_ParseEpair (void *base, ddef_t *key, char *s)
 	switch (key->type & ~DEF_SAVEGLOBAL)
 	{
 	case ev_string:
-		*(string_t *)d = PR1_SetString(ED_NewString (s));
+		PR1_SetString((string_t *)d, ED_NewString (s));
 		break;
 
 	case ev_float:
@@ -1055,8 +1056,8 @@ qbool PR1_ClientCmd(void)
 		static char cmd_copy[128], args_copy[1024] /* Ouch! */;
 		strlcpy (cmd_copy, Cmd_Argv(0), sizeof(cmd_copy));
 		strlcpy (args_copy, Cmd_Args(), sizeof(args_copy));
-		((int *)pr_globals)[OFS_PARM0] = PR1_SetString (cmd_copy);
-		((int *)pr_globals)[OFS_PARM1] = PR1_SetString (args_copy);
+		PR1_SetString (&((int *)pr_globals)[OFS_PARM0], cmd_copy);
+		PR1_SetString (&((int *)pr_globals)[OFS_PARM1], args_copy);
 		PR_ExecuteProgram (GE_ClientCommand);
 		return G_FLOAT(OFS_RETURN) ? true : false;
 	}
@@ -1065,7 +1066,7 @@ qbool PR1_ClientCmd(void)
 	{
 		static char cmd_copy[128];
 		strlcpy (cmd_copy, Cmd_Argv(0), sizeof(cmd_copy));
-		((int *)pr_globals)[OFS_PARM0] = PR1_SetString (cmd_copy);
+		PR1_SetString (&((int *)pr_globals)[OFS_PARM0], cmd_copy);
 
 		PR_ExecuteProgram (mod_UserCmd);
 		return G_FLOAT(OFS_RETURN) ? true : false;

--- a/src/pr_edict.c
+++ b/src/pr_edict.c
@@ -124,9 +124,9 @@ edict_t *ED_Alloc (void)
 		}
 	}
 
-	if (i == MAX_EDICTS)
+	if (i == sv.max_edicts)
 	{
-		Con_Printf ("WARNING: ED_Alloc: no free edicts\n");
+		Con_Printf ("WARNING: ED_Alloc: no free edicts [%d]\n", sv.max_edicts);
 		i--;	// step on whatever is the last edict
 		e = EDICT_NUM(i);
 		SV_UnlinkEdict(e);
@@ -1227,6 +1227,7 @@ void PR1_LoadProgs (void)
 void PR1_InitProg()
 {
 	sv.edicts = (edict_t*) Hunk_AllocName (MAX_EDICTS * pr_edict_size, "edicts");
+	sv.max_edicts = MAX_EDICTS;
 }
 
 /*
@@ -1251,7 +1252,7 @@ void PR1_Init (void)
 
 edict_t *EDICT_NUM(int n)
 {
-	if (n < 0 || n >= MAX_EDICTS)
+	if (n < 0 || n >= sv.max_edicts)
 		SV_Error ("EDICT_NUM: bad number %i", n);
 	return (edict_t *)((byte *)sv.edicts+ (n)*pr_edict_size);
 }

--- a/src/pr_edict.c
+++ b/src/pr_edict.c
@@ -1225,7 +1225,7 @@ void PR1_LoadProgs (void)
 	PR_InitBuiltins();
 }
 
-void PR1_InitProg()
+void PR1_InitProg(void)
 {
 	sv.edicts = (edict_t*) Hunk_AllocName (MAX_EDICTS * pr_edict_size, "edicts");
 	sv.max_edicts = MAX_EDICTS;

--- a/src/pr_exec.c
+++ b/src/pr_exec.c
@@ -692,24 +692,33 @@ char *PR1_GetString(int num)
 	return pr_strings + num;
 }
 
-int PR1_SetString(char *s)
+void PR1_SetString(string_t* address, char* s)
 {
 	int i;
 
-	if (s - pr_strings < 0)
-	{
-		for (i = 0; i < num_prstr; i++)
-			if (pr_strtbl[i] == s)
-				return -i;
+	if (!address) {
+		return;
+	}
 
-		if (num_prstr + 1 >= MAX_PRSTR)
+	if (s - pr_strings < 0) {
+		for (i = 0; i < num_prstr; i++) {
+			if (pr_strtbl[i] == s) {
+				*address = -i;
+				return;
+			}
+		}
+
+		if (num_prstr + 1 >= MAX_PRSTR) {
 			Sys_Error("MAX_PRSTR");
+		}
 
 		pr_strtbl[++num_prstr] = s;
 		//Con_DPrintf("SET:%d == %s\n", -num_prstr, s);
-		return -num_prstr;
+		*address = -num_prstr;
 	}
-	return (int)(s - pr_strings);
+	else {
+		*address = (int)(s - pr_strings);
+	}
 }
 
 /*
@@ -721,7 +730,7 @@ many calls to function could cause strtbl overflow
 ==============
 */
 
-int PR_SetTmpString(const char *s)
+void PR_SetTmpString(string_t* target, const char *s)
 {
 	static int index1;
 	static char tmp[8][2048];
@@ -729,7 +738,7 @@ int PR_SetTmpString(const char *s)
 	index1 = (index1 + 1) & 7;
 
 	strlcpy(tmp[index1], s, sizeof(tmp[index1]));
-	return PR1_SetString(tmp[index1]);
+	PR1_SetString(target, tmp[index1]);
 }
 
 //=============================================================================
@@ -822,7 +831,7 @@ qbool PR1_ClientSay(int isTeamSay, char *message)
 			message[max(0,(int)strlen(message)-1)] = 0;   // truncate closing ".
 		}
 
-		G_INT(OFS_PARM0) = PR_SetTmpString(message);
+		PR_SetTmpString(&G_INT(OFS_PARM0), message);
 		G_FLOAT(OFS_PARM1) = (float)isTeamSay;
 
 		PR_ExecuteProgram(mod_ChatMessage);

--- a/src/pr_exec.c
+++ b/src/pr_exec.c
@@ -855,7 +855,7 @@ void PR1_PausedTic(float duration)
 
 //=============================================================================
 
-void PR1_UnLoadProgs()
+void PR1_UnLoadProgs(void)
 {
 	if (progs)
 	{

--- a/src/progs.h
+++ b/src/progs.h
@@ -211,8 +211,8 @@ extern char *pr_newstrtbl[MAX_PRSTR];
 extern int num_prstr;
 
 char *PR1_GetString(int num);
-int PR1_SetString(char *s);
-int PR_SetTmpString(const char *s);
+void PR1_SetString(string_t* address, char* s);
+void PR_SetTmpString(string_t* address, const char *s);
 
 void PR1_LoadProgs (void);
 void PR1_InitProg();
@@ -248,8 +248,10 @@ qbool PR1_ClientCmd(void);
 	#define PR_UnLoadProgs PR1_UnLoadProgs
 
 	#define PR_Init PR1_Init
-	#define PR_GetString PR1_GetString
-	#define PR_SetString PR1_SetString
+	//#define PR_GetString PR1_GetString
+	//#define PR_SetString PR1_SetString
+	#define PR_SetEntityString(ent, target, value) PR1_SetString(&target, value)
+	#define PR_SetGlobalString(target, value) PR1_SetString(&target, value)
 	#define ED_FindFieldOffset ED1_FindFieldOffset
 	#define PR_GetEdictFieldValue PR1_GetEdictFieldValue
 
@@ -271,6 +273,8 @@ qbool PR1_ClientCmd(void);
 	#define PR_EdictThink PR1_EdictThink
 	#define PR_EdictTouch PR1_EdictTouch
 	#define PR_EdictBlocked PR1_EdictBlocked
+
+	#define PR_ClearEdict(ent)
 #endif
 
 // pr_cmds.c

--- a/src/progs.h
+++ b/src/progs.h
@@ -52,7 +52,7 @@ typedef struct sv_edict_s
 	qbool		free;
 	link_t		area;			// linked to a division node or leaf
 
-	int			entnum;
+	int         entnum;
 
 	int			num_leafs;
 	short		leafnums[MAX_ENT_LEAFS];
@@ -84,10 +84,10 @@ extern	dstatement_t	*pr_statements;
 extern	globalvars_t	*pr_global_struct;
 extern	float		*pr_globals;	// same as pr_global_struct
 
-extern	int			pr_edict_size;	// in bytes
-extern	cvar_t		sv_progsname; 
+extern	int         pr_edict_size;	// in bytes
+extern	cvar_t      sv_progsname; 
 #ifdef WITH_NQPROGS
-extern	cvar_t		sv_forcenqprogs;
+extern	cvar_t      sv_forcenqprogs;
 #endif
 
 //============================================================================
@@ -116,7 +116,7 @@ void NQP_Reset (void);
 
 //============================================================================
 
-void PR1_Init (void);
+void PR_Init (void);
 
 void PR_ExecuteProgram (func_t fnum);
 void PR_InitPatchTables (void);	// NQ progs support
@@ -216,6 +216,7 @@ int PR_SetTmpString(const char *s);
 
 void PR1_LoadProgs (void);
 void PR1_InitProg();
+void PR1_Init(void);
 
 #define PR1_GameShutDown()	// PR1 does not really have it.
 void PR1_UnLoadProgs();
@@ -234,7 +235,7 @@ qbool PR1_ClientCmd(void);
 #define PR1_GameStartFrame() PR_ExecuteProgram (PR_GLOBAL(StartFrame))
 #define PR1_ClientKill() PR_ExecuteProgram (PR_GLOBAL(ClientKill))
 #define PR1_UserInfoChanged() (0) // PR1 does not really have it,
-								  // we have mod_UserInfo_Changed but it is slightly different.
+                                  // we have mod_UserInfo_Changed but it is slightly different.
 #define PR1_LoadEnts ED_LoadFromFile
 #define PR1_EdictThink PR_ExecuteProgram
 #define PR1_EdictTouch PR_ExecuteProgram

--- a/src/progs.h
+++ b/src/progs.h
@@ -232,7 +232,7 @@ qbool PR1_ClientCmd(void);
 
 #define PR1_GameSetChangeParms() PR_ExecuteProgram(PR_GLOBAL(SetChangeParms))
 #define PR1_GameSetNewParms() PR_ExecuteProgram(PR_GLOBAL(SetNewParms))
-#define PR1_GameStartFrame() PR_ExecuteProgram (PR_GLOBAL(StartFrame))
+#define PR1_GameStartFrame(isBotFrame) PR_ExecuteProgram (PR_GLOBAL(StartFrame))
 #define PR1_ClientKill() PR_ExecuteProgram (PR_GLOBAL(ClientKill))
 #define PR1_UserInfoChanged() (0) // PR1 does not really have it,
                                   // we have mod_UserInfo_Changed but it is slightly different.

--- a/src/progs.h
+++ b/src/progs.h
@@ -187,6 +187,7 @@ extern int fofs_gravity, fofs_maxspeed;
 extern int fofs_hideentity;
 extern int fofs_trackent;
 extern int fofs_visibility;
+extern int fofs_hide_players;
 
 #define EdictFieldFloat(ed, fieldoffset) ((eval_t *)((byte *)&(ed)->v + (fieldoffset)))->_float
 #define EdictFieldVector(ed, fieldoffset) ((eval_t *)((byte *)&(ed)->v + (fieldoffset)))->vector

--- a/src/progs.h
+++ b/src/progs.h
@@ -186,6 +186,7 @@ extern int fofs_movement;
 extern int fofs_gravity, fofs_maxspeed;
 extern int fofs_hideentity;
 extern int fofs_trackent;
+extern int fofs_visibility;
 
 #define EdictFieldFloat(ed, fieldoffset) ((eval_t *)((byte *)&(ed)->v + (fieldoffset)))->_float
 #define EdictFieldVector(ed, fieldoffset) ((eval_t *)((byte *)&(ed)->v + (fieldoffset)))->vector

--- a/src/progs.h
+++ b/src/progs.h
@@ -215,11 +215,11 @@ void PR1_SetString(string_t* address, char* s);
 void PR_SetTmpString(string_t* address, const char *s);
 
 void PR1_LoadProgs (void);
-void PR1_InitProg();
+void PR1_InitProg(void);
 void PR1_Init(void);
 
 #define PR1_GameShutDown()	// PR1 does not really have it.
-void PR1_UnLoadProgs();
+void PR1_UnLoadProgs(void);
 
 void PR1_GameClientDisconnect(int spec);
 void PR1_GameClientConnect(int spec);
@@ -232,7 +232,7 @@ qbool PR1_ClientCmd(void);
 
 #define PR1_GameSetChangeParms() PR_ExecuteProgram(PR_GLOBAL(SetChangeParms))
 #define PR1_GameSetNewParms() PR_ExecuteProgram(PR_GLOBAL(SetNewParms))
-#define PR1_GameStartFrame(isBotFrame) PR_ExecuteProgram (PR_GLOBAL(StartFrame))
+#define PR1_GameStartFrame() PR_ExecuteProgram (PR_GLOBAL(StartFrame))
 #define PR1_ClientKill() PR_ExecuteProgram (PR_GLOBAL(ClientKill))
 #define PR1_UserInfoChanged() (0) // PR1 does not really have it,
                                   // we have mod_UserInfo_Changed but it is slightly different.
@@ -266,7 +266,7 @@ qbool PR1_ClientCmd(void);
 
 	#define PR_GameSetChangeParms PR1_GameSetChangeParms
 	#define PR_GameSetNewParms PR1_GameSetNewParms
-	#define PR_GameStartFrame PR1_GameStartFrame
+	#define PR_GameStartFrame(isBotFrame) { if (!isBotFrame) { PR1_GameStartFrame(); } }
 	#define PR_ClientKill PR1_ClientKill
 	#define PR_UserInfoChanged PR1_UserInfoChanged
 	#define PR_LoadEnts PR1_LoadEnts

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -34,8 +34,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // fte protocol extensions.
 
-#define PROTOCOL_VERSION_FTE			(('F'<<0) + ('T'<<8) + ('E'<<16) + ('X' << 24))
-#define PROTOCOL_VERSION_FTE2			(('F'<<0) + ('T'<<8) + ('E'<<16) + ('2' << 24))
+#define PROTOCOL_VERSION_FTE            (('F'<<0) + ('T'<<8) + ('E'<<16) + ('X' << 24))
+#define PROTOCOL_VERSION_FTE2           (('F'<<0) + ('T'<<8) + ('E'<<16) + ('2' << 24))
+#define PROTOCOL_VERSION_MVD1           (('M'<<0) + ('V'<<8) + ('D'<<16) + ('1' << 24))
 
 //
 // Not all of that really supported.
@@ -62,6 +63,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define FTE_PEXT2_VOICECHAT			0x00000002
 
 #endif // PROTOCOL_VERSION_FTE2
+
+#ifdef PROTOCOL_VERSION_MVD1
+
+#define MVD_PEXT1_FLOATCOORDS       0x00000001 // FTE_PEXT_FLOATCOORDS but for entity/player coords only
+
+#endif // PROTOCOL_VERSION_MVD1
 
 //==============================================
 

--- a/src/server.h
+++ b/src/server.h
@@ -966,7 +966,7 @@ void	SV_MVDInfoAdd_f (void);
 void	SV_MVDInfoRemove_f (void);
 void	SV_MVDInfo_f (void);
 void	SV_LastScores_f (void);
-char*   SV_MVDName2Txt (char *name);
+char*   SV_MVDName2Txt (const char *name);
 
 //
 // sv_demo_qtv.c
@@ -983,6 +983,7 @@ void DemoWriteQTV (sizebuf_t *msg);
 void QTVsv_FreeUserList(mvddest_t *d);
 void QTV_Streams_List (void);
 void QTV_Streams_UserList (void);
+const char* SV_MVDDemoName(void);
 
 //
 // sv_login.c

--- a/src/server.h
+++ b/src/server.h
@@ -294,6 +294,10 @@ typedef struct client_s
 #ifdef PROTOCOL_VERSION_FTE2
 	unsigned int	fteprotocolextensions2;
 #endif // PROTOCOL_VERSION_FTE2
+
+#ifdef PROTOCOL_VERSION_MVD1
+	unsigned int    mvdprotocolextensions1;
+#endif
  
 #ifdef FTE_PEXT2_VOICECHAT
 	unsigned int voice_read;	/*place in ring*/
@@ -547,6 +551,10 @@ typedef struct
 #ifdef PROTOCOL_VERSION_FTE2
 	unsigned int fteprotocolextensions2;
 #endif // PROTOCOL_VERSION_FTE2
+
+#ifdef PROTOCOL_VERSION_MVD1
+	unsigned int mvdprotocolextension1;
+#endif
 
 	// log messages are used so that fraglog processes can get stats
 	int				logsequence;		// the message currently being filled

--- a/src/server.h
+++ b/src/server.h
@@ -90,11 +90,13 @@ typedef struct
 	char		*lightstyles[MAX_LIGHTSTYLES];
 	cmodel_t	*models[MAX_MODELS];
 
-	int		num_edicts;			// increases towards MAX_EDICTS
-	edict_t		*edicts;			// can NOT be array indexed, because
-							// edict_t is variable sized, but can
-							// be used to reference the world ent
-	sv_edict_t	sv_edicts[MAX_EDICTS]; // part of the edict_t
+	int         num_edicts;         // increases towards MAX_EDICTS
+	int         num_baseline_edicts;// number of entities that have baselines
+	edict_t     *edicts;            // can NOT be array indexed, because
+	                                // edict_t is variable sized, but can
+	                                // be used to reference the world ent
+	sv_edict_t  sv_edicts[MAX_EDICTS]; // part of the edict_t
+	int         max_edicts;         // might not MAX_EDICTS if mod allocates memory
 
 	byte		*pvs, *phs;			// fully expanded and decompressed
 
@@ -120,6 +122,9 @@ typedef struct
 	byte		signon_buffers[MAX_SIGNON_BUFFERS][MAX_DATAGRAM];
 
 	qbool		mvdrecording;
+
+	entity_state_t static_entities[512];
+	int            static_entity_count;
 } server_t;
 
 #define	NUM_SPAWN_PARMS 16
@@ -991,5 +996,7 @@ void Master_Heartbeat (void);
 void SV_SaveGame_f (void); 
 void SV_LoadGame_f (void); 
 
+//
+void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, sizebuf_t *msg, qbool force);
 
 #endif /* !__SERVER_H__ */

--- a/src/server.h
+++ b/src/server.h
@@ -169,11 +169,14 @@ typedef struct
 	vec3_t			origin;
 } antilag_position_t;
 
-#define MAX_ANTILAG_POSITIONS	128
-#define MAX_BACK_BUFFERS	128
-#define MAX_STUFFTEXT		256
-#define	CLIENT_LOGIN_LEN	16
-#define	CLIENT_NAME_LEN		32
+#define MAX_ANTILAG_POSITIONS      128
+#define MAX_BACK_BUFFERS           128
+#define MAX_STUFFTEXT              256
+#define	CLIENT_LOGIN_LEN            16
+#define	CLIENT_NAME_LEN             32
+#define LOGIN_CHALLENGE_LENGTH     128
+#define LOGIN_MIN_RETRY_TIME         5    // 1 login attempt per x seconds
+
 typedef struct client_s
 {
 	sv_client_state_t	state;
@@ -275,7 +278,9 @@ typedef struct client_s
 	qbool			remote_snap;
 
 	char			login[CLIENT_LOGIN_LEN];
+	char            challenge[LOGIN_CHALLENGE_LENGTH];
 	int				logged;
+	double          login_request_time;
 
 	int				spawncount;			// for tracking map changes during downloading
 
@@ -961,6 +966,7 @@ void	SV_MVDInfoAdd_f (void);
 void	SV_MVDInfoRemove_f (void);
 void	SV_MVDInfo_f (void);
 void	SV_LastScores_f (void);
+char*   SV_MVDName2Txt (char *name);
 
 //
 // sv_demo_qtv.c
@@ -1005,5 +1011,8 @@ void SV_LoadGame_f (void);
 //
 void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, sizebuf_t *msg, qbool force);
 qbool SV_SkipCommsBotMessage(client_t* client);
+
+// 
+#include "central.h"
 
 #endif /* !__SERVER_H__ */

--- a/src/server.h
+++ b/src/server.h
@@ -843,6 +843,7 @@ void SV_SendServerInfoChange (char *key, char *value);
 // sv_ents.c
 //
 void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder);
+void SV_SetVisibleEntitiesForBot (client_t* client);
 
 //
 // sv_nchan.c

--- a/src/server.h
+++ b/src/server.h
@@ -947,10 +947,6 @@ void	SV_LastScores_f (void);
 // sv_demo_qtv.c
 //
 
-extern cvar_t	qtv_streamport;
-extern cvar_t	qtv_maxstreams;
-extern cvar_t	qtv_password;
-extern cvar_t	qtv_pendingtimeout;
 extern cvar_t	qtv_streamtimeout;
 
 

--- a/src/server.h
+++ b/src/server.h
@@ -1000,5 +1000,6 @@ void SV_LoadGame_f (void);
 
 //
 void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, sizebuf_t *msg, qbool force);
+qbool SV_SkipCommsBotMessage(client_t* client);
 
 #endif /* !__SERVER_H__ */

--- a/src/server.h
+++ b/src/server.h
@@ -428,6 +428,9 @@ typedef struct mvddest_s
 	char			qtvname[64];
 
 	qtvuser_t		*qtvuserlist;
+
+	char            qtvaddress[128];
+	int             qtvstreamid;
 // }
 
 	struct mvddest_s *nextdest;
@@ -956,6 +959,8 @@ void SV_QTV_Init(void);
 
 void DemoWriteQTV (sizebuf_t *msg);
 void QTVsv_FreeUserList(mvddest_t *d);
+void QTV_Streams_List (void);
+void QTV_Streams_UserList (void);
 
 //
 // sv_login.c

--- a/src/server.h
+++ b/src/server.h
@@ -211,7 +211,7 @@ typedef struct client_s
 	char			name[CLIENT_NAME_LEN];		// for printing to other people
 
 	char			team[CLIENT_NAME_LEN];
-							// extracted from userinfo
+	// extracted from userinfo
 	int				messagelevel;			// for filtering printed messages
 
 	// the datagram is written to after every frame, but only cleared
@@ -249,9 +249,11 @@ typedef struct client_s
 	client_frame_t	frames[UPDATE_BACKUP];		// updates can be deltad from here
 
 	vfsfile_t		*download;			// file being downloaded
+#ifdef PROTOCOL_VERSION_FTE
 #ifdef FTE_PEXT_CHUNKEDDOWNLOADS
 	int				download_chunks_perframe;
-#endif // FTE_PEXT_CHUNKEDDOWNLOADS
+#endif
+#endif
 	int				downloadsize;			// total bytes
 	int				downloadcount;			// bytes sent
 // demo download list for internal cmd dl function
@@ -514,16 +516,16 @@ typedef struct
 // TCPCONNECT -->
 typedef struct svtcpstream_s
 {
-	int				socketnum; // socket
-	qbool			waitingforprotocolconfirmation; // wait for "qizmo\n", first 6 bytes before confirming that is tcpconnection
-	int				inlen; // how much bytes we have in inbuffer
-	char			inbuffer[1500]; // recv buffer
-	int				outlen; // how much bytes we have in outbuffer
-	char			outbuffer[1500 * 5]; // send buffer
-	qbool			drop; // do we need drop that connection ASAP
-	float			timeouttime; // I/O timeout
-	netadr_t		remoteaddr; // peer remoter addr
-	struct svtcpstream_s *next; // next tcpconnection in list
+	int                     socketnum;                         // socket
+	qbool                   waitingforprotocolconfirmation;    // wait for "qizmo\n", first 6 bytes before confirming that is tcpconnection
+	int                     inlen;                             // how much bytes we have in inbuffer
+	char                    inbuffer[1500];                    // recv buffer
+	int                     outlen;                            // how much bytes we have in outbuffer
+	char                    outbuffer[1500 * 5];               // send buffer
+	qbool                   drop;                              // do we need drop that connection ASAP
+	float                   timeouttime;                       // I/O timeout
+	netadr_t                remoteaddr;                        // peer remoter addr
+	struct svtcpstream_s    *next;                             // next tcpconnection in list
 } svtcpstream_t;
 // <-- TCPCONNECT
 

--- a/src/server.h
+++ b/src/server.h
@@ -63,6 +63,7 @@ typedef struct
 
 	double		time;
 	double		old_time;			// bumped by SV_Physics
+	double      old_bot_time;       // bumped by SV_RunBots
 
 	double		physicstime;		// last time physics was run
 
@@ -116,12 +117,12 @@ typedef struct
 	// includes the entity baselines, the static entities, etc
 	// large levels will have >MAX_DATAGRAM sized signons, so 
 	// multiple signon messages are kept
-	sizebuf_t	signon;
-	unsigned int	num_signon_buffers;
-	int		signon_buffer_size[MAX_SIGNON_BUFFERS];
-	byte		signon_buffers[MAX_SIGNON_BUFFERS][MAX_DATAGRAM];
+	sizebuf_t      signon;
+	unsigned int   num_signon_buffers;
+	int            signon_buffer_size[MAX_SIGNON_BUFFERS];
+	byte           signon_buffers[MAX_SIGNON_BUFFERS][MAX_DATAGRAM];
 
-	qbool		mvdrecording;
+	qbool		   mvdrecording;
 
 	entity_state_t static_entities[512];
 	int            static_entity_count;
@@ -794,7 +795,7 @@ void SV_SpawnServer (char *server, qbool devmap, char* entityfile);
 //
 // sv_phys.c
 //
-void SV_ProgStartFrame (void);
+void SV_ProgStartFrame (qbool isBotFrame);
 void SV_Physics (void);
 void SV_CheckVelocity (edict_t *ent);
 void SV_AddGravity (edict_t *ent, float scale);
@@ -804,6 +805,9 @@ void SV_RunNewmis (void);
 void SV_RunNQNewmis (void);
 void SV_Impact (edict_t *e1, edict_t *e2);
 void SV_SetMoveVars(void);
+#ifdef USE_PR2
+void SV_RunBots(void);
+#endif
 
 //
 // sv_send.c

--- a/src/server.h
+++ b/src/server.h
@@ -1014,6 +1014,8 @@ void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, s
 qbool SV_SkipCommsBotMessage(client_t* client);
 
 // 
+#ifdef SERVERONLY
 #include "central.h"
+#endif
 
 #endif /* !__SERVER_H__ */

--- a/src/sv_ccmds.c
+++ b/src/sv_ccmds.c
@@ -531,6 +531,7 @@ void SV_ListFiles_f (void)
 	dirname = Cmd_Argv(1);
 	SV_ReplaceChar(dirname, '\\', '/');
 
+	// Double-check then move to FS_UnsafeFilename() ?
 	if (	!strncmp(dirname, "../", 3) || strstr(dirname, "/../") || *dirname == '/'
 	        ||	( (i = strlen(dirname)) < 3 ? 0 : !strncmp(dirname + i - 3, "/..", 4) )
 	        ||	!strncmp(dirname, "..", 3)

--- a/src/sv_ccmds.c
+++ b/src/sv_ccmds.c
@@ -1456,9 +1456,9 @@ void SV_Localinfo_Set (const char *name, const char *value)
 	{
 		pr_global_struct->time = sv.time;
 		pr_global_struct->self = 0;
-		G_INT(OFS_PARM0) = PR_SetTmpString(name);
-		G_INT(OFS_PARM1) = PR_SetTmpString(old_value);
-		G_INT(OFS_PARM2) = PR_SetTmpString(Info_Get(&_localinfo_, name));
+		PR_SetTmpString(&G_INT(OFS_PARM0), name);
+		PR_SetTmpString(&G_INT(OFS_PARM1), old_value);
+		PR_SetTmpString(&G_INT(OFS_PARM2), Info_Get(&_localinfo_, name));
 		PR_ExecuteProgram (mod_localinfoChanged);
 	}
 }

--- a/src/sv_ccmds.c
+++ b/src/sv_ccmds.c
@@ -491,6 +491,9 @@ void SV_Map (qbool now)
 	}
 
 	changed = true;
+#ifndef SERVERONLY
+	com_serveractive = true;
+#endif
 }
 
 void SV_Map_f (void)

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1188,7 +1188,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t *dest)
 	MSG_WriteFloat (&buf, sv.time);
 
 	// send full levelname
-	MSG_WriteString (&buf, PR_GetString(sv.edicts->v.message));
+	MSG_WriteString (&buf, PR_GetEntityString(sv.edicts->v.message));
 
 	// send the movevars
 	MSG_WriteFloat(&buf, movevars.gravity);
@@ -1511,7 +1511,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t *dest)
 		memset(stats, 0, sizeof(stats));
 
 		stats[STAT_HEALTH]       = ent->v.health;
-		stats[STAT_WEAPON]       = SV_ModelIndex(PR_GetString(ent->v.weaponmodel));
+		stats[STAT_WEAPON]       = SV_ModelIndex(PR_GetEntityString(ent->v.weaponmodel));
 		stats[STAT_AMMO]         = ent->v.currentammo;
 		stats[STAT_ARMOR]        = ent->v.armorvalue;
 		stats[STAT_SHELLS]       = ent->v.ammo_shells;
@@ -1802,4 +1802,20 @@ void SV_MVDInit (void)
 	Cmd_AddCommand ("script",			SV_Script_f);
 
 	SV_QTV_Init();
+}
+
+const char* SV_MVDDemoName(void)
+{
+	mvddest_t* d;
+
+	for (d = demo.dest; d; d = d->nextdest) {
+		if (d->desttype == DEST_STREAM) {
+			continue; // streams are not saved on to HDD, so ignore it...
+		}
+		if (d->name && d->name[0]) {
+			return d->name;
+		}
+	}
+
+	return NULL;
 }

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1274,8 +1274,75 @@ void SV_MVD_SendInitialGamestate(mvddest_t *dest)
 		SZ_Clear (&buf);
 	}
 
-	// prespawn
+	// static entities
+	{
+		int i, j;
+		entity_state_t from = { 0 };
 
+		for (i = 0; i < sv.static_entity_count; ++i) {
+			entity_state_t* s = &sv.static_entities[i];
+
+			if (buf.cursize >= MAX_MSGLEN/2) {
+				SV_WriteRecordMVDMessage (&buf);
+				SZ_Clear (&buf);
+			}
+
+			if (demo.recorder.fteprotocolextensions & FTE_PEXT_SPAWNSTATIC2) {
+				MSG_WriteByte(&buf, svc_fte_spawnstatic2);
+				SV_WriteDelta(&demo.recorder, &from, s, &buf, true);
+			}
+			else if (s->modelindex < 256) {
+				MSG_WriteByte(&buf, svc_spawnstatic);
+				MSG_WriteByte(&buf, s->modelindex);
+				MSG_WriteByte(&buf, s->frame);
+				MSG_WriteByte(&buf, s->colormap);
+				MSG_WriteByte(&buf, s->skinnum);
+				for (j = 0; j < 3; ++j) {
+					MSG_WriteCoord(&buf, s->origin[j]);
+					MSG_WriteAngle(&buf, s->angles[j]);
+				}
+			}
+		}
+	}
+
+	// entity baselines
+	{
+		static entity_state_t empty_baseline = { 0 };
+		int i, j;
+
+		for (i = 0; i < sv.num_baseline_edicts; ++i) {
+			edict_t* svent = EDICT_NUM(i);
+			entity_state_t* s = &svent->e->baseline;
+
+			if (buf.cursize >= MAX_MSGLEN/2) {
+				SV_WriteRecordMVDMessage (&buf);
+				SZ_Clear (&buf);
+			}
+
+			if (!s->number || !s->modelindex || !memcmp(s, &empty_baseline, sizeof(empty_baseline))) {
+				continue;
+			}
+
+			if (demo.recorder.fteprotocolextensions & FTE_PEXT_SPAWNSTATIC2) {
+				MSG_WriteByte(&buf, svc_fte_spawnbaseline2);
+				SV_WriteDelta(&demo.recorder, &empty_baseline, s, &buf, true);
+			}
+			else if (s->modelindex < 256) {
+				MSG_WriteByte(&buf, svc_spawnbaseline);
+				MSG_WriteShort(&buf, i);
+				MSG_WriteByte(&buf, s->modelindex);
+				MSG_WriteByte(&buf, s->frame);
+				MSG_WriteByte(&buf, s->colormap);
+				MSG_WriteByte(&buf, s->skinnum);
+				for (j = 0; j < 3; j++) {
+					MSG_WriteCoord(&buf, s->origin[j]);
+					MSG_WriteAngle(&buf, s->angles[j]);
+				}
+			}
+		}
+	}
+
+	// prespawn
 	for (n = 0; n < sv.num_signon_buffers; n++)
 	{
 		if (buf.cursize+sv.signon_buffer_size[n] > MAX_MSGLEN/2)

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -21,7 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "qwsvdef.h"
 
-// minimal chache which can be used for demos, must be few times greater than DEMO_FLUSH_CACHE_IF_LESS_THAN_THIS
+// minimal cache which can be used for demos, must be few times greater than DEMO_FLUSH_CACHE_IF_LESS_THAN_THIS
 #define DEMO_CACHE_MIN_SIZE 0x1000000
 
 // flush demo cache if we have less than this free bytes
@@ -789,7 +789,7 @@ static mvddest_t *SV_InitRecordFile (char *name)
 
 	if ( !sv_silentrecord.value )
 		SV_BroadcastPrintf (PRINT_CHAT, "Server starts recording (%s):\n%s\n",
-						(dst->desttype == DEST_BUFFEREDFILE) ? "memory" : "disk", s+1);
+		                    (dst->desttype == DEST_BUFFEREDFILE) ? "memory" : "disk", s+1);
 	Cvar_SetROM(&serverdemo, dst->name);
 
 	strlcpy(path, name, MAX_OSPATH);
@@ -1792,6 +1792,7 @@ void SV_MVDInit (void)
 	Cmd_AddCommand ("sv_lastscores",	SV_LastScores_f);
 	Cmd_AddCommand ("sv_demolist",		SV_DemoList_f);
 	Cmd_AddCommand ("sv_demolistr",		SV_DemoListRegex_f);
+	Cmd_AddCommand ("sv_demolistregex",	SV_DemoListRegex_f);
 	Cmd_AddCommand ("sv_demoremove",	SV_MVDRemove_f);
 	Cmd_AddCommand ("sv_demonumremove",	SV_MVDRemoveNum_f);
 	Cmd_AddCommand ("sv_demoinfoadd",	SV_MVDInfoAdd_f);

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -514,7 +514,7 @@ char *SV_MVDNum (int num)
 }
 
 #define OVECCOUNT 3
-static char *SV_MVDName2Txt (char *name)
+char *SV_MVDName2Txt (char *name)
 {
 	char	s[MAX_OSPATH];
 	int		len;

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -20,6 +20,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 // sv_demo_misc.c - misc demo related stuff, helpers
 
 #include "qwsvdef.h"
+#ifndef SERVERONLY
+#include "pcre.h"
+#endif
 
 static char chartbl[256];
 
@@ -30,7 +33,7 @@ CleanName_Init
 sets chararcter table for quake text->filename translation
 ====================
 */
-void CleanName_Init ()
+void CleanName_Init (void)
 {
 	int i;
 
@@ -232,8 +235,12 @@ void Run_sv_demotxt_and_sv_onrecordfinish (const char *dest_name, const char *de
 			*p = 0; // strip parameters
 	
 		strlcpy(path, dest_name, sizeof(path));
+#ifdef SERVERONLY
 		COM_StripExtension(path);
-	
+#else
+		COM_StripExtension(path, path, sizeof(path));
+#endif
+
 		sv_redirected = RD_NONE; // onrecord script is called always from the console
 		Cmd_TokenizeString(va("script %s \"%s\" \"%s\" %s", sv_onrecordfinish.string, dest_path, path, p != NULL ? p+1 : ""));
 
@@ -963,7 +970,7 @@ void SV_LastScores_f (void)
 
 // easyrecord helpers
 
-int Dem_CountPlayers ()
+int Dem_CountPlayers (void)
 {
 	int	i, count;
 

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -514,7 +514,7 @@ char *SV_MVDNum (int num)
 }
 
 #define OVECCOUNT 3
-char *SV_MVDName2Txt (char *name)
+char *SV_MVDName2Txt (const char *name)
 {
 	char	s[MAX_OSPATH];
 	int		len;
@@ -731,24 +731,20 @@ void SV_MVDInfoAdd_f (void)
 		return;
 	}
 
-	if (!strcmp(Cmd_Argv(1), "*") || !strcmp(Cmd_Argv(1), "**"))
-	{
-		if (!sv.mvdrecording || !demo.dest)
-		{
+	if (!strcmp(Cmd_Argv(1), "*") || !strcmp(Cmd_Argv(1), "**")) {
+		const char* demoname = SV_MVDDemoName();
+
+		if (!sv.mvdrecording || !demoname) {
 			Con_Printf("Not recording demo!\n");
 			return;
 		}
 
-//		snprintf(path, MAX_OSPATH, "%s/%s/%s", fs_gamedir, demo.path, SV_MVDName2Txt(demo.name));
-// FIXME: dunno is this right, just using first dest, also may be we must use demo.dest->path instead of sv_demoDir
-		snprintf(path, MAX_OSPATH, "%s/%s/%s", fs_gamedir, sv_demoDir.string, SV_MVDName2Txt(demo.dest->name));
+		snprintf(path, MAX_OSPATH, "%s/%s/%s", fs_gamedir, sv_demoDir.string, SV_MVDName2Txt(demoname));
 	}
-	else
-	{
+	else {
 		name = SV_MVDTxTNum(Q_atoi(Cmd_Argv(1)));
 
-		if (!name)
-		{
+		if (!name) {
 			Con_Printf("invalid demo num\n");
 			return;
 		}

--- a/src/sv_demo_qtv.c
+++ b/src/sv_demo_qtv.c
@@ -28,6 +28,9 @@ static cvar_t qtv_pendingtimeout = {"qtv_pendingtimeout",  "5"}; // 5  seconds m
 static cvar_t qtv_sayenabled     = {"qtv_sayenabled",      "0"}; // allow mod to override GameStarted() logic
 cvar_t qtv_streamtimeout         = {"qtv_streamtimeout",  "45"}; // 45 seconds
 
+static unsigned short int	listenport		= 0;
+static double				warned_time		= 0;
+
 static mvddest_t *SV_InitStream (int socket1, netadr_t na, char *userinfo)
 {
 	static int lastdest = 0;
@@ -111,9 +114,6 @@ void SV_MVDCloseStreams(void)
 			p->error = true; // mark pending dest to close later
 }
 
-static unsigned short int	listenport		= 0;
-static double				warned_time		= 0;
-
 static void SV_CheckQTVPort(void)
 {
 	qbool changed;
@@ -122,9 +122,9 @@ static void SV_CheckQTVPort(void)
 
 	// if we have non zero stream port, but fail to open listen socket, repeat open listen socket after some time
 	changed = ( streamport != listenport // port changed.
-				|| (streamport  && NET_GetSocket(NS_SERVER, true) == INVALID_SOCKET && warned_time + 10 < Sys_DoubleTime()) // stream port non zero but socket still not open, lets open socket then.
-				|| (!streamport && NET_GetSocket(NS_SERVER, true) != INVALID_SOCKET) // stream port is zero but socket still open, lets close socket then.
-		);
+	    || (streamport  && NET_GetSocket(NS_SERVER, true) == INVALID_SOCKET && warned_time + 10 < Sys_DoubleTime()) // stream port non zero but socket still not open, lets open socket then.
+	    || (!streamport && NET_GetSocket(NS_SERVER, true) != INVALID_SOCKET) // stream port is zero but socket still open, lets close socket then.
+	);
 
 	// port not changed
 	if (!changed)

--- a/src/sv_demo_qtv.c
+++ b/src/sv_demo_qtv.c
@@ -694,6 +694,7 @@ void QTVcmd_Say_f(mvddest_t *d)
 	int		j;
 	char	*p;
 	char	text[1024], text2[1024], *cmd;
+	int     sent_to = 0;
 
 	if (Cmd_Argc () < 2)
 		return;
@@ -742,6 +743,9 @@ void QTVcmd_Say_f(mvddest_t *d)
 			continue; // game started, don't send QTV chat to players, specs still get QTV chat
 
 		SV_ClientPrintf2(client, PRINT_CHAT, "%s", text);
+		if (!client->spectator) {
+			sent_to |= (1 << j);
+		}
 	}
 
 	if (sv.mvdrecording) {

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -35,6 +35,8 @@ extern	int sv_nailmodel, sv_supernailmodel, sv_playermodel;
 
 cvar_t	sv_nailhack	= {"sv_nailhack", "1"};
 
+// Maximum packet we will send - currently 256 if extension supported
+#define MAX_PACKETENTITIES_POSSIBLE 256
 
 static qbool SV_AddNailUpdate (edict_t *ent)
 {
@@ -115,10 +117,14 @@ Writes part of a packetentities message.
 Can delta from either a baseline or a previous packet_entity
 ==================
 */
-static void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, sizebuf_t *msg, qbool force)
+void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, sizebuf_t *msg, qbool force)
 {
 	int bits, i;
-
+#ifdef PROTOCOL_VERSION_FTE
+	int evenmorebits = 0;
+	unsigned int required_extensions = 0;
+	unsigned int fte_extensions = client->fteprotocolextensions;
+#endif
 
 	// send an update
 	bits = 0;
@@ -148,8 +154,15 @@ static void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t
 	if (to->effects != from->effects)
 		bits |= U_EFFECTS;
 
-	if (to->modelindex != from->modelindex)
+	if (to->modelindex != from->modelindex) {
 		bits |= U_MODEL;
+#ifdef FTE_PEXT_ENTITYDBL
+		if (to->modelindex > 255) {
+			evenmorebits |= U_FTE_MODELDBL;
+			required_extensions |= FTE_PEXT_MODELDBL;
+		}
+#endif
+	}
 
 	if (bits & U_CHECKMOREBITS)
 		bits |= U_MOREBITS;
@@ -157,17 +170,59 @@ static void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t
 	if (to->flags & U_SOLID)
 		bits |= U_SOLID;
 
+	// Taken from FTE
+	if (msg->cursize + 40 > msg->maxsize)
+	{	//not enough space in the buffer, don't send the entity this frame. (not sending means nothing changes, and it takes no bytes!!)
+		*to = *from;
+		return;
+	}
+
 	//
 	// write the message
 	//
 	if (!to->number)
 		SV_Error("Unset entity number");
-	if (to->number >= MAX_EDICTS) {
-		/*SV_Error*/
-		Con_Printf("Entity number >= MAX_EDICTS (%d), set to MAX_EDICTS - 1\n", MAX_EDICTS);
-		to->number = MAX_EDICTS - 1;
+
+#ifdef PROTOCOL_VERSION_FTE
+	if (to->number >= 512)
+	{
+		if (to->number >= 1024)
+		{
+			if (to->number >= 1024 + 512) {
+				evenmorebits |= U_FTE_ENTITYDBL;
+				required_extensions |= FTE_PEXT_ENTITYDBL;
+			}
+
+			evenmorebits |= U_FTE_ENTITYDBL2;
+			required_extensions |= FTE_PEXT_ENTITYDBL2;
+			if (to->number >= 2048)
+				SV_Error ("Entity number >= 2048");
+		}
+		else {
+			evenmorebits |= U_FTE_ENTITYDBL;
+			required_extensions |= FTE_PEXT_ENTITYDBL;
+		}
 	}
 
+	if (evenmorebits&0xff00)
+		evenmorebits |= U_FTE_YETMORE;
+	if (evenmorebits&0x00ff)
+		bits |= U_FTE_EVENMORE;
+	if (bits & 511)
+		bits |= U_MOREBITS;
+#endif
+
+	if (to->number >= sv.max_edicts) {
+		/*SV_Error*/
+		Con_Printf("Entity number >= MAX_EDICTS (%d), set to MAX_EDICTS - 1\n", sv.max_edicts);
+		to->number = sv.max_edicts - 1;
+	}
+
+#ifdef PROTOCOL_VERSION_FTE
+	if (evenmorebits && (fte_extensions & required_extensions) != required_extensions) {
+		return;
+	}
+#endif
 	if (!bits && !force)
 		return;		// nothing to send!
 	i = to->number | (bits&~U_CHECKMOREBITS);
@@ -177,8 +232,15 @@ static void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t
 
 	if (bits & U_MOREBITS)
 		MSG_WriteByte(msg, bits & 255);
+#ifdef PROTOCOL_VERSION_FTE
+	if (bits & U_FTE_EVENMORE)
+		MSG_WriteByte (msg, evenmorebits&255);
+	if (evenmorebits & U_FTE_YETMORE)
+		MSG_WriteByte (msg, (evenmorebits>>8)&255);
+#endif
+
 	if (bits & U_MODEL)
-		MSG_WriteByte(msg, to->modelindex);
+		MSG_WriteByte(msg, to->modelindex & 255);
 	if (bits & U_FRAME)
 		MSG_WriteByte(msg, to->frame);
 	if (bits & U_COLORMAP)
@@ -290,9 +352,28 @@ static void SV_EmitPacketEntities (client_t *client, packet_entities_t *to, size
 		}
 
 		if (newnum > oldnum)
-		{	// the old entity isn't present in the new message
-			//Con_Printf ("remove %i,%i\n", oldnum, newnum);
-			MSG_WriteShort (msg, oldnum | U_REMOVE);
+		{
+			// the old entity isn't present in the new message
+			if (oldnum >= 512) {
+				//yup, this is expensive.
+				MSG_WriteShort (msg, oldnum | U_REMOVE | U_MOREBITS);
+				MSG_WriteByte (msg, U_FTE_EVENMORE);
+				if (oldnum >= 1024) {
+					if (oldnum >= 1024 + 512) {
+						MSG_WriteByte(msg, U_FTE_ENTITYDBL | U_FTE_ENTITYDBL2);
+					}
+					else {
+						MSG_WriteByte(msg, U_FTE_ENTITYDBL2);
+					}
+				}
+				else {
+					MSG_WriteByte(msg, U_FTE_ENTITYDBL);
+				}
+			}
+			else {
+				MSG_WriteShort(msg, oldnum | U_REMOVE);
+			}
+
 			oldindex++;
 			continue;
 		}
@@ -396,15 +477,16 @@ qbool SV_PlayerVisibleToClient (client_t* client, int j, byte* pvs, edict_t* sel
 		if (cl->spectator)
 			return false;
 
-		// ignore if not touching a PV leaf
-		if ( pvs )
-		{
-			for (i=0 ; i < ent->e->num_leafs ; i++)
-				if (pvs[ent->e->leafnums[i] >> 3] & (1 << (ent->e->leafnums[i]&7) ))
+		if (pvs && ent->e->num_leafs >= 0) {
+			// ignore if not touching a PV leaf
+			for (i = 0; i < ent->e->num_leafs; i++) {
+				if (pvs[ent->e->leafnums[i] >> 3] & (1 << (ent->e->leafnums[i] & 7))) {
 					break;
-
-			if (i == ent->e->num_leafs)
+				}
+			}
+			if (i == ent->e->num_leafs) {
 				return false; // not visible
+			}
 		}
 	}
 
@@ -503,7 +585,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 				pflags |= PF_VELOCITY1<<i;
 		if (ent->v.effects)
 			pflags |= PF_EFFECTS;
-		if (ent->v.skin)
+		if (ent->v.skin || ent->v.modelindex >= 256)
 			pflags |= PF_SKINNUM;
 		if (ent->v.health <= 0)
 			pflags |= PF_DEAD;
@@ -633,7 +715,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 			MSG_WriteByte (msg, ent->v.modelindex);
 
 		if (pflags & PF_SKINNUM)
-			MSG_WriteByte (msg, ent->v.skin);
+			MSG_WriteByte (msg, (int)ent->v.skin | (((pflags & PF_MODEL)&&(ent->v.modelindex >= 256))<<7));
 
 		if (pflags & PF_EFFECTS)
 			MSG_WriteByte (msg, TranslateEffects(ent));
@@ -663,7 +745,7 @@ qbool SV_EntityVisibleToClient (client_t* client, int e, byte* pvs)
 	if (!ent->v.modelindex || !*PR_GetString(ent->v.model))
 		return false;
 
-	if ( pvs )
+	if ( pvs && ent->e->num_leafs >= 0 )
 	{
 		int i;
 
@@ -701,6 +783,12 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 	byte *pvs;
 	int hideent;
 	unsigned int client_flag = (1 << (client - svs.clients));
+	edict_t	*clent = client->edict;
+
+	float distances[MAX_PACKETENTITIES_POSSIBLE] = { 0 };
+	float distance;
+	int position;
+	vec3_t org;
 
 	if ( recorder )
 	{
@@ -781,7 +869,7 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 	{// Vladis, server flash
 
 		// QW protocol can only handle 512 entities. Any entity with number >= 512 will be invisible
-		// From ZQuake.
+		// from ZQuake unless using protocol extensions.
 		// max_edicts = min(sv.num_edicts, MAX_EDICTS);
 
 		for (e = pr_nqprogs ? 1 : MAX_CLIENTS + 1, ent = EDICT_NUM(e); e < sv.num_edicts; e++, ent = NEXT_EDICT(ent))
@@ -805,12 +893,50 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 			if (SV_AddNailUpdate (ent))
 				continue; // added to the special update list
 
-			// add to the packetentities
-			if (pack->num_entities == max_packet_entities)
-				continue;	// all full
+			if (clent) {
+				VectorAdd(ent->v.absmin, ent->v.absmax, org);
+				VectorMA(clent->v.origin, -0.5, org, org);
+				distance = DotProduct(org, org);	//Length
 
-			state = &pack->entities[pack->num_entities];
-			pack->num_entities++;
+				// add to the packetentities
+				if (pack->num_entities == max_packet_entities) {
+					// replace the furthest entity
+					float furthestdist = -1;
+					int best = -1;
+					for (i = 0; i < max_packet_entities; i++) {
+						if (furthestdist < distances[i]) {
+							furthestdist = distances[i];
+							best = i;
+						}
+					}
+
+					if (furthestdist <= distance || best == -1) {
+						continue;
+					}
+
+					// shuffle other entities down, add to end
+					if (best < pack->num_entities - 1) {
+						memmove(&pack->entities[best], &pack->entities[best + 1], sizeof(pack->entities[0]) * (pack->num_entities - 1 - best));
+						memmove(&distances[best], &distances[best + 1], sizeof(distances[0]) * (pack->num_entities - 1 - best));
+					}
+					position = pack->num_entities - 1;
+				}
+				else {
+					position = pack->num_entities++;
+				}
+
+				distances[position] = distance;
+			}
+			else {
+				if (pack->num_entities == max_packet_entities) {
+					continue;
+				}
+
+				position = pack->num_entities++;
+			}
+
+			state = &pack->entities[position];
+			memset(state, 0, sizeof(*state));
 
 			state->number = e;
 			state->flags = 0;
@@ -841,10 +967,12 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 			if (!ent->v.modelindex || !*PR_GetString(ent->v.model))
 				continue;
 
-			// ignore if not touching a PV leaf
-			for (i=0 ; i < ent->e->num_leafs ; i++)
-				if (pvs[ent->e->leafnums[i] >> 3] & (1 << (ent->e->leafnums[i]&7) ))
-					break;
+			// ignore if not touching a PV leaf (meag: this does nothing... complete or remove?)
+			if (pvs && ent->e->num_leafs >= 0) {
+				for (i = 0; i < ent->e->num_leafs; i++)
+					if (pvs[ent->e->leafnums[i] >> 3] & (1 << (ent->e->leafnums[i] & 7)))
+						break;
+			}
 
 			if ((int)ent->v.effects & EF_MUZZLEFLASH) {
 				ent->v.effects = (int)ent->v.effects & ~EF_MUZZLEFLASH;

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -1028,3 +1028,10 @@ void SV_SetVisibleEntitiesForBot (client_t* client)
 		}
 	}
 }
+
+qbool SV_SkipCommsBotMessage(client_t* client)
+{
+	extern cvar_t sv_serveme_fix;
+
+	return sv_serveme_fix.value && client->spectator && !strcmp(client->name, "[ServeMe]");
+}

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -223,9 +223,10 @@ void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, s
 		return;
 	}
 #endif
-	if (!bits && !force)
+	if (!bits && !force) {
 		return;		// nothing to send!
-	i = to->number | (bits&~U_CHECKMOREBITS);
+	}
+	i = (to->number & U_CHECKMOREBITS) | (bits&~U_CHECKMOREBITS);
 	if (i & U_REMOVE)
 		Sys_Error("U_REMOVE");
 	MSG_WriteShort(msg, i);
@@ -257,8 +258,9 @@ void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, s
 			MSG_WriteCoord(msg, to->origin[0]);
 		}
 	}
-	if (bits & U_ANGLE1)
+	if (bits & U_ANGLE1) {
 		MSG_WriteAngle(msg, to->angles[0]);
+	}
 	if (bits & U_ORIGIN2) {
 		if (client->mvdprotocolextensions1 & MVD_PEXT1_FLOATCOORDS) {
 			MSG_WriteLongCoord(msg, to->origin[1]);
@@ -267,8 +269,9 @@ void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, s
 			MSG_WriteCoord(msg, to->origin[1]);
 		}
 	}
-	if (bits & U_ANGLE2)
+	if (bits & U_ANGLE2) {
 		MSG_WriteAngle(msg, to->angles[1]);
+	}
 	if (bits & U_ORIGIN3) {
 		if (client->mvdprotocolextensions1 & MVD_PEXT1_FLOATCOORDS) {
 			MSG_WriteLongCoord(msg, to->origin[2]);
@@ -277,8 +280,9 @@ void SV_WriteDelta(client_t* client, entity_state_t *from, entity_state_t *to, s
 			MSG_WriteCoord(msg, to->origin[2]);
 		}
 	}
-	if (bits & U_ANGLE3)
+	if (bits & U_ANGLE3) {
 		MSG_WriteAngle(msg, to->angles[2]);
+	}
 }
 
 /*
@@ -295,7 +299,6 @@ static void SV_EmitPacketEntities (client_t *client, packet_entities_t *to, size
 	client_frame_t	*fromframe;
 	packet_entities_t *from1;
 	edict_t	*ent;
-
 
 	// this is the frame that we are going to delta update from
 	if (client->delta_sequence != -1)
@@ -450,7 +453,7 @@ static void SV_MVD_WritePlayersToClient ( void )
 		demo.fixangle[j] = 0;
 
 		dcl->sec         = sv.time - cl->localtime;
-		
+
 		if (ent->v.health <= 0)
 			dcl->flags |= DF_DEAD;
 		if (ent->v.mins[2] != -24)
@@ -699,8 +702,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 				cmd.upmove = 0;
 			}
 
-			if ((client->extensions & Z_EXT_VWEP) && sv.vw_model_name[0]
-					&& fofs_vw_index) {
+			if ((client->extensions & Z_EXT_VWEP) && sv.vw_model_name[0] && fofs_vw_index) {
 				cmd.impulse = EdictFieldFloat (ent, fofs_vw_index);
 			}
 

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -407,6 +407,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 	usercmd_t cmd;
 	int hideent = 0;
 	int trackent = 0;
+	qbool hide_players = fofs_hide_players && ((eval_t *)((byte *)&(client->edict)->v + fofs_hide_players))->_int;
 
 	if (fofs_hideentity)
 		hideent = ((eval_t *)((byte *)&(client->edict)->v + fofs_hideentity))->_int / pr_edict_size;
@@ -422,10 +423,10 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 
 	for (j = 0; j < MAX_CLIENTS; j++)
 	{
-		client_t *	cl = &svs.clients[j];
-		edict_t *	ent = NULL;
-		edict_t *	self_ent = NULL;
-		edict_t *	track_ent = NULL;
+		client_t*   cl = &svs.clients[j];
+		edict_t*    ent = NULL;
+		edict_t*    self_ent = NULL;
+		edict_t*    track_ent = NULL;
 
 		if (fofs_visibility) {
 			// Presume not visible
@@ -433,6 +434,9 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		}
 
 		if (cl->state != cs_spawned)
+			continue;
+
+		if (client != cl && hide_players)
 			continue;
 
 		if (trackent && cl == client)
@@ -447,7 +451,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		else
 		{
 			self_ent = client->edict;
-			ent = cl->edict;		
+			ent = cl->edict;
 		}
 
 		// set up edicts.

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -744,7 +744,7 @@ qbool SV_EntityVisibleToClient (client_t* client, int e, byte* pvs)
 	}
 
 	// ignore ents without visible models
-	if (!ent->v.modelindex || !*PR_GetString(ent->v.model))
+	if (!ent->v.modelindex || !*PR_GetEntityString(ent->v.model))
 		return false;
 
 	if ( pvs && ent->e->num_leafs >= 0 )
@@ -966,7 +966,7 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 		for (e=1, ent=EDICT_NUM(e) ; e < sv.num_edicts ; e++, ent = NEXT_EDICT(ent))
 		{
 			// ignore ents without visible models
-			if (!ent->v.modelindex || !*PR_GetString(ent->v.model))
+			if (!ent->v.modelindex || !*PR_GetEntityString(ent->v.model))
 				continue;
 
 			// ignore if not touching a PV leaf (meag: this does nothing... complete or remove?)

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -297,7 +297,7 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 	// wipe the entire per-level structure
 	// NOTE: this also set sv.mvdrecording to false, so calling SV_MVD_Record() at end of function
 	memset (&sv, 0, sizeof(sv));
-
+	sv.max_edicts = MAX_EDICTS_SAFE;
 
 	sv.datagram.maxsize = sizeof(sv.datagram_buf);
 	sv.datagram.data = sv.datagram_buf;

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -478,7 +478,7 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 
 	// run the frame start qc function to let progs check cvars
 	if (!pr_nqprogs)
-		SV_ProgStartFrame ();
+		SV_ProgStartFrame (false);
 
 	// ********* External Entity support (.ent file(s) in gamedir/maps) pinched from ZQuake *********
 	// load and spawn all other entities

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -92,8 +92,8 @@ baseline will be transmitted
 */
 static void SV_CreateBaseline (void)
 {
-	edict_t			*svent;
-	int				entnum;
+	edict_t  *svent;
+	int      entnum;
 
 	for (entnum = 0; entnum < sv.num_edicts ; entnum++)
 	{
@@ -126,7 +126,6 @@ static void SV_CreateBaseline (void)
 	}
 	sv.num_baseline_edicts = sv.num_edicts;
 }
-
 
 /*
 ================
@@ -246,7 +245,6 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 			svs.clients[i].isBot = 0;
 		}
 	}
-
 #endif
 
 	// Shutdown game.
@@ -320,7 +318,6 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 	// load progs to get entity field count
 	// which determines how big each edict is
 	// and allocate edicts
-
 	PR_LoadProgs ();
 #ifdef WITH_NQPROGS
 	PR_InitPatchTables();
@@ -418,14 +415,13 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 	}
 	else
 #endif
-
 	{
 		sv.sound_precache[0] = pr_strings;
 		sv.model_precache[0] = pr_strings;
 	}
 	sv.model_precache[1] = sv.modelname;
 	sv.models[1] = sv.worldmodel;
-	for (i=1 ; i< CM_NumInlineModels() ; i++)
+	for (i = 1; i < CM_NumInlineModels(); i++)
 	{
 		sv.model_precache[1+i] = localmodels[i];
 		sv.models[i+1] =  CM_InlineModel (localmodels[i]);
@@ -516,7 +512,7 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 	if (!entitystring) {
 		entitystring = CM_EntityString();
 	}
-	
+
 	PR_LoadEnts(entitystring);
 	// ********* End of External Entity support code *********
 

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -330,6 +330,7 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 		ent->e = &sv.sv_edicts[i]; // assigning ->e field in each edict_t
 		ent->e->entnum = i;
 		ent->e->area.ed = ent; // yeah, pretty funny, but this help to find which edict_t own this area (link_t)
+		PR_ClearEdict(ent);
 	}
 
 	fofs_items2 = ED_FindFieldOffset ("items2"); // ZQ_ITEMS2 extension
@@ -362,7 +363,7 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 	{
 		ent = EDICT_NUM(i+1);
 		// restore client name.
-		ent->v.netname = PR_SetString(svs.clients[i].name);
+		PR_SetEntityString(ent, ent->v.netname, svs.clients[i].name);
 		// reserve edict.
 		svs.clients[i].edict = ent;
 		//ZOID - make sure we update frags right
@@ -445,18 +446,18 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 
 	ent = EDICT_NUM(0);
 	ent->e->free = false;
-	ent->v.model = PR_SetString(sv.modelname);
+	PR_SetEntityString(ent, ent->v.model, sv.modelname);
 	ent->v.modelindex = 1;		// world model
 	ent->v.solid = SOLID_BSP;
 	ent->v.movetype = MOVETYPE_PUSH;
 
 	// information about the server
-	ent->v.netname = PR_SetString(VersionStringFull());
-	ent->v.targetname = PR_SetString(SERVER_NAME);
+	PR_SetEntityString(ent, ent->v.netname, VersionStringFull());
+	PR_SetEntityString(ent, ent->v.targetname, SERVER_NAME);
 	ent->v.impulse = VERSION_NUM;
 	ent->v.items = pr_numbuiltins - 1;
 
-	PR_GLOBAL(mapname) = PR_SetString(sv.mapname);
+	PR_SetGlobalString(PR_GLOBAL(mapname), sv.mapname);
 	// serverflags are for cross level information (sigils)
 	PR_GLOBAL(serverflags) = svs.serverflags;
 	if (pr_nqprogs)

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -36,6 +36,7 @@ int fofs_movement;
 int fofs_vw_index;
 int fofs_hideentity;
 int fofs_trackent;
+int fofs_visibility;
 
 /*
 ================
@@ -361,6 +362,7 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 	fofs_vw_index = ED_FindFieldOffset ("vw_index");
 	fofs_hideentity = ED_FindFieldOffset ("hideentity");
 	fofs_trackent = ED_FindFieldOffset ("trackent");
+	fofs_visibility = ED_FindFieldOffset ("visclients");
 
 	// find optional QC-exported functions.
 	// we have it here, so we set it to NULL in case of PR2 progs.

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -37,6 +37,7 @@ int fofs_vw_index;
 int fofs_hideentity;
 int fofs_trackent;
 int fofs_visibility;
+int fofs_hide_players;
 
 /*
 ================
@@ -363,6 +364,7 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 	fofs_hideentity = ED_FindFieldOffset ("hideentity");
 	fofs_trackent = ED_FindFieldOffset ("trackent");
 	fofs_visibility = ED_FindFieldOffset ("visclients");
+	fofs_hide_players = ED_FindFieldOffset ("hideplayers");
 
 	// find optional QC-exported functions.
 	// we have it here, so we set it to NULL in case of PR2 progs.

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -262,6 +262,13 @@ void SV_SpawnServer (char *mapname, qbool devmap, char* entityfile)
 
 	Host_ClearMemory();
 
+#ifndef SERVERONLY
+	if (!oldmap[0]) {
+		Cbuf_InsertTextEx(&cbuf_server, "exec server.cfg\n");
+		Cbuf_ExecuteEx(&cbuf_server);
+	}
+#endif
+
 #ifdef FTE_PEXT_FLOATCOORDS
 	if (sv_bigcoords.value)
 	{

--- a/src/sv_login.c
+++ b/src/sv_login.c
@@ -70,7 +70,7 @@ Writes account list to disk
 =================
 */
 
-static void WriteAccounts()
+static void WriteAccounts(void)
 {
 	int c;
 	FILE *f;
@@ -650,7 +650,7 @@ void SV_ParseLogin(client_t *cl)
 		MSG_WriteString (&cl->netchan.message, va("Welcome %s\n", log1));
 
 		//VVD: forcenick ->
-		if ((int)sv_forcenick.value && cl->login)
+		if ((int)sv_forcenick.value && cl->login[0])
 		{
 			char oldval[MAX_EXT_INFO_STRING];
 			strlcpy (oldval, cl->name, MAX_EXT_INFO_STRING);

--- a/src/sv_login.c
+++ b/src/sv_login.c
@@ -35,17 +35,17 @@ typedef enum {use_log, use_ip} quse_t;
 
 typedef struct
 {
-	char		login[MAX_LOGINNAME];
-	char		pass[MAX_LOGINNAME];
-	int		failures;
-	int		inuse;
-	ipfilter_t	adress;
-	acc_state_t	state;
-	quse_t		use;
+	char        login[MAX_LOGINNAME];
+	char        pass[MAX_LOGINNAME];
+	int         failures;
+	int         inuse;
+	ipfilter_t  adress;
+	acc_state_t state;
+	quse_t      use;
 } account_t;
 
-static account_t	accounts[MAX_ACCOUNTS];
-static int		num_accounts = 0;
+static account_t accounts[MAX_ACCOUNTS];
+static int       num_accounts = 0;
 
 static qbool validAcc(char *acc)
 {

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -178,6 +178,9 @@ cvar_t registered = {"registered", "1", CVAR_ROM};
 cvar_t	sv_halflifebsp = {"halflifebsp", "0", CVAR_ROM};
 cvar_t  sv_bspversion = {"sv_bspversion", "1", CVAR_ROM};
 
+// If set, don't send broadcast messages, entities or player info to ServeMe bot
+cvar_t sv_serveme_fix = { "sv_serveme_fix", "1", CVAR_ROM };
+
 #ifdef FTE_PEXT_FLOATCOORDS
 cvar_t sv_bigcoords = {"sv_bigcoords", "", CVAR_SERVERINFO};
 #endif
@@ -3408,6 +3411,7 @@ void SV_InitLocal (void)
 
 	Cvar_Register (&sv_halflifebsp);
 	Cvar_Register (&sv_bspversion);
+	Cvar_Register (&sv_serveme_fix);
 
 #ifdef FTE_PEXT_FLOATCOORDS
 	Cvar_Register (&sv_bigcoords);

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -432,8 +432,9 @@ int SV_CalcPing (client_t *cl)
 	ping = 0;
 	count = 0;
 #ifdef USE_PR2
-	if( cl->isBot )
-		return ((int) (sv_mintic.value * 1000));
+	if (cl->isBot) {
+		return 10;
+	}
 #endif
 	for (frame = cl->frames, i=0 ; i<UPDATE_BACKUP ; i++, frame++)
 	{
@@ -3218,8 +3219,12 @@ void SV_Frame (double time1)
 	SV_ReadPackets ();
 
 	// move autonomous things around if enough time has passed
-	if (!sv.paused)
-		SV_Physics ();
+	if (!sv.paused) {
+		SV_Physics();
+#ifdef USE_PR2
+		SV_RunBots();
+#endif
+	}
 	else
 		PausedTic ();
 

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -236,6 +236,8 @@ void SV_Shutdown (char *finalmsg)
 	NET_CloseServer ();
 #endif
 
+	Central_Shutdown();
+
 	// Shutdown game.
 	PR_GameShutDown();
 	PR_UnLoadProgs();
@@ -3231,6 +3233,8 @@ void SV_Frame (double time1)
 	// send messages back to the clients that had packets read this frame
 	SV_SendClientMessages ();
 
+	Central_ProcessResponses();
+
 	demo_start = Sys_DoubleTime ();
 	SV_SendDemoMessage();
 	demo_end = Sys_DoubleTime ();
@@ -3848,6 +3852,8 @@ void SV_Init (void)
 #ifndef SERVERONLY
 	server_cfg_done = true;
 #endif
+
+	Central_Init ();
 }
 
 /*

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -172,10 +172,13 @@ cvar_t sv_registrationinfo = {"sv_registrationinfo", ""}; // text shown before "
 cvar_t registered = {"registered", "1", CVAR_ROM};
 
 cvar_t	sv_halflifebsp = {"halflifebsp", "0", CVAR_ROM};
+cvar_t  sv_bspversion = {"sv_bspversion", "1", CVAR_ROM};
 
 #ifdef FTE_PEXT_FLOATCOORDS
 cvar_t sv_bigcoords = {"sv_bigcoords", "", CVAR_SERVERINFO};
 #endif
+
+cvar_t sv_extlimits = { "sv_extlimits", "2" };
 
 qbool sv_error = false;
 
@@ -3400,10 +3403,13 @@ void SV_InitLocal (void)
 	Cvar_Register (&registered);
 
 	Cvar_Register (&sv_halflifebsp);
+	Cvar_Register (&sv_bspversion);
 
 #ifdef FTE_PEXT_FLOATCOORDS
 	Cvar_Register (&sv_bigcoords);
 #endif
+
+	Cvar_Register (&sv_extlimits);
 
 	Cvar_Register (&sv_reliable_sound);
 
@@ -3435,6 +3441,18 @@ void SV_InitLocal (void)
 #endif
 #ifdef FTE_PEXT_FLOATCOORDS
 	svs.fteprotocolextensions |= FTE_PEXT_FLOATCOORDS;
+#endif
+#ifdef FTE_PEXT_MODELDBL
+	svs.fteprotocolextensions |= FTE_PEXT_MODELDBL;
+#endif
+#ifdef FTE_PEXT_ENTITYDBL
+	svs.fteprotocolextensions |= FTE_PEXT_ENTITYDBL;
+#endif
+#ifdef FTE_PEXT_ENTITYDBL2
+	svs.fteprotocolextensions |= FTE_PEXT_ENTITYDBL2;
+#endif
+#ifdef FTE_PEXT_SPAWNSTATIC2
+	svs.fteprotocolextensions |= FTE_PEXT_SPAWNSTATIC2;
 #endif
 
 #ifdef FTE_PEXT2_VOICECHAT

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -308,7 +308,7 @@ void SV_FinalMessage (const char *message)
 	MSG_WriteByte (&net_message, svc_disconnect);
 
 	for (i=0, cl = svs.clients ; i<MAX_CLIENTS ; i++, cl++)
-		if (cl->state >= cs_spawned)
+		if (cl->state >= cs_spawned && ! cl->isBot)
 			Netchan_Transmit (&cl->netchan, net_message.cursize
 			                  , net_message.data);
 }

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -809,6 +809,21 @@ static void SVC_GetChallenge (void)
 	}
 #endif // PROTOCOL_VERSION_FTE2
 
+#ifdef PROTOCOL_VERSION_MVD1
+	// tell the client what mvdsv extensions we support
+	if (svs.mvdprotocolextension1) {
+		int lng;
+
+		lng = LittleLong(PROTOCOL_VERSION_MVD1);
+		memcpy(over, &lng, sizeof(int));
+		over += 4;
+
+		lng = LittleLong(svs.mvdprotocolextension1);
+		memcpy(over, &lng, sizeof(int));
+		over += 4;
+	}
+#endif
+
 	Netchan_OutOfBand(NS_SERVER, net_from, over-buf, (byte*) buf);
 }
 
@@ -1151,6 +1166,10 @@ static void SVC_DirectConnect (void)
 	unsigned int protextsupported2 = 0;
 #endif // PROTOCOL_VERSION_FTE2
 
+#ifdef PROTOCOL_VERSION_MVD1
+	unsigned int mvdext_supported1 = 0;
+#endif
+
 	// check version/protocol
 	if ( !CheckProtocol( Q_atoi( Cmd_Argv( 1 ) ) ) )
 		return; // wrong protocol number
@@ -1189,6 +1208,13 @@ static void SVC_DirectConnect (void)
 			Con_DPrintf("Client supports 0x%x fte extensions2\n", protextsupported2);
 			break;
 #endif // PROTOCOL_VERSION_FTE2
+
+#ifdef PROTOCOL_VERSION_MVD1
+		case PROTOCOL_VERSION_MVD1:
+			mvdext_supported1 = Q_atoi( Cmd_Argv( 1 ) );
+			Con_DPrintf("Client supports 0x%x mvdsv extensions\n", mvdext_supported1);
+			break;
+#endif
 		}
 	}
 
@@ -1269,6 +1295,10 @@ static void SVC_DirectConnect (void)
 #ifdef PROTOCOL_VERSION_FTE2
 	newcl->fteprotocolextensions2 = protextsupported2;
 #endif // PROTOCOL_VERSION_FTE2
+
+#ifdef PROTOCOL_VERSION_MVD1
+	newcl->mvdprotocolextensions1 = mvdext_supported1;
+#endif
 
 	newcl->_userinfo_ctx_.max      = MAX_CLIENT_INFOS;
 	newcl->_userinfoshort_ctx_.max = MAX_CLIENT_INFOS;
@@ -3409,6 +3439,10 @@ void SV_InitLocal (void)
 
 #ifdef FTE_PEXT2_VOICECHAT
 	svs.fteprotocolextensions2 |= FTE_PEXT2_VOICECHAT;
+#endif
+
+#ifdef MVD_PEXT1_FLOATCOORDS
+	svs.mvdprotocolextension1 |= MVD_PEXT1_FLOATCOORDS;
 #endif
 
 	Info_SetValueForStarKey (svs.info, "*version", SERVER_NAME " " VERSION_NUMBER, MAX_SERVERINFO_STRING);

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -1356,7 +1356,7 @@ static void SVC_DirectConnect (void)
 	ent->e->free = false;
 	newcl->edict = ent;
 	// restore client name.
-	ent->v.netname = PR_SetString(newcl->name);
+	PR_SetEntityString(ent, ent->v.netname, newcl->name);
 
 	s = ( vip ? va("%d", vip) : "" );
 

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -236,7 +236,7 @@ void SV_Shutdown (char *finalmsg)
 	NET_CloseServer ();
 #endif
 
-#ifdef SERVERONLY
+#if defined(SERVERONLY) && defined(WWW_INTEGRATION)
 	Central_Shutdown();
 #endif
 
@@ -3230,7 +3230,7 @@ void SV_Frame (double time1)
 	// send messages back to the clients that had packets read this frame
 	SV_SendClientMessages ();
 
-#ifdef SERVERONLY
+#if defined(SERVERONLY) && defined(WWW_INTEGRATION)
 	Central_ProcessResponses();
 #endif
 
@@ -3852,7 +3852,7 @@ void SV_Init (void)
 	server_cfg_done = true;
 #endif
 
-#ifdef SERVERONLY
+#if defined(SERVERONLY) && defined(WWW_INTEGRATION)
 	Central_Init ();
 #endif
 }

--- a/src/sv_mod_frags.c
+++ b/src/sv_mod_frags.c
@@ -28,6 +28,9 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
 #include "qwsvdef.h"
+#ifndef SERVERONLY
+#include "pcre.h"
+#endif
 #include "sv_mod_frags.h"
 
 qwmsg_t *qwmsg[MOD_MSG_MAX + 1];
@@ -37,13 +40,11 @@ void free_qwmsg_t(qwmsg_t **qwmsg1)
 {
 	int i;
 
-	if (qwm_static)
-		return;
-
-	for (i = 0; qwmsg1[i]; i++)
-	{
-		Q_free(qwmsg1[i]->str);
-		Q_free(qwmsg1[i]);
+	if (!qwm_static) {
+		for (i = 0; qwmsg1[i]; i++) {
+			Q_free(qwmsg1[i]->str);
+			Q_free(qwmsg1[i]);
+		}
 	}
 }
 
@@ -64,11 +65,8 @@ void sv_mod_msg_file_OnChange(cvar_t *cvar, char *value, qbool *cancel)
 		if (value[0])
 			Con_Printf("WARNING: sv_mod_msg_file_OnChange: can't open file %s.\n", value);
 
-		for (i = 0; i < MOD_MSG_MAX && qwmsg_def[i].str; i++)
-		{
+		for (i = 0; i < MOD_MSG_MAX && qwmsg_def[i].str; i++) {
 			qwmsg[i] = &qwmsg_def[i];
-//			Sys_Printf("msg_type = %d, id = %d, pl_count = %d, str = %s, reverse = %d\n",
-//			qwmsg[i]->msg_type, qwmsg[i]->id, qwmsg[i]->pl_count, qwmsg[i]->str, qwmsg[i]->reverse);
 		}
 		qwm_static = true;
 		Con_DPrintf("Initialized default mod messages.\nTotal: %d messages.\n", i);
@@ -94,7 +92,8 @@ void sv_mod_msg_file_OnChange(cvar_t *cvar, char *value, qbool *cancel)
 				qwmsg[i]->reverse = Q_atoi(str_tok) ? true : false;
 				// fill str
 				str_tok = (char *)strtok(NULL, "#");
-				len = strlen(str_tok+1);
+
+				len = strlen (str_tok) + 1;
 				qwmsg[i]->str =  (char *) Q_malloc (len);
 				strlcpy(qwmsg[i]->str, str_tok, len);
 			}

--- a/src/sv_phys.c
+++ b/src/sv_phys.c
@@ -1011,7 +1011,7 @@ void SV_Physics (void)
 		sv_client = cl;
 		sv_player = cl->edict;
 
-		if( sv_client->spectator && sv_client->spec_track > 0 )
+		if (sv_client->spectator && sv_client->spec_track > 0)
 			sv_player->v.goalentity = EDICT_TO_PROG(svs.clients[sv_client->spec_track-1].edict);
 	}
 
@@ -1067,14 +1067,14 @@ void SV_Physics (void)
 
 void SV_SetMoveVars(void)
 {
-	movevars.gravity		= sv_gravity.value;
-	movevars.stopspeed		= sv_stopspeed.value;
-	movevars.maxspeed		= sv_maxspeed.value;
-	movevars.spectatormaxspeed	= sv_spectatormaxspeed.value;
-	movevars.accelerate		= sv_accelerate.value;
-	movevars.airaccelerate		= sv_airaccelerate.value;
-	movevars.wateraccelerate	= sv_wateraccelerate.value;
-	movevars.friction		= sv_friction.value;
-	movevars.waterfriction		= sv_waterfriction.value;
-	movevars.entgravity		= 1.0;
+	movevars.gravity            = sv_gravity.value;
+	movevars.stopspeed          = sv_stopspeed.value;
+	movevars.maxspeed           = sv_maxspeed.value;
+	movevars.spectatormaxspeed  = sv_spectatormaxspeed.value;
+	movevars.accelerate         = sv_accelerate.value;
+	movevars.airaccelerate      = sv_airaccelerate.value;
+	movevars.wateraccelerate    = sv_wateraccelerate.value;
+	movevars.friction           = sv_friction.value;
+	movevars.waterfriction      = sv_waterfriction.value;
+	movevars.entgravity         = 1.0;
 }

--- a/src/sv_phys.c
+++ b/src/sv_phys.c
@@ -1022,7 +1022,7 @@ void SV_Physics (void)
 	for ( i = 0, cl = svs.clients; i < MAX_CLIENTS; i++, cl++ )
 	{
 		extern void SV_PreRunCmd(void);
-		extern void SV_RunCmd (usercmd_t *ucmd, qbool inside);
+		extern void SV_RunCmd (usercmd_t *ucmd, qbool inside, qbool simulate);
 		extern void SV_PostRunCmd(void);
 
 		if ( cl->state == cs_free )
@@ -1034,7 +1034,7 @@ void SV_Physics (void)
 		sv_player = cl->edict;
 
 		SV_PreRunCmd();
-		SV_RunCmd (&cl->botcmd, false);
+		SV_RunCmd (&cl->botcmd, false, false);
 		SV_PostRunCmd();
 
 		cl->lastcmd = cl->botcmd;

--- a/src/sv_phys.c
+++ b/src/sv_phys.c
@@ -95,12 +95,12 @@ void SV_CheckVelocity (edict_t *ent)
 	{
 		if (IS_NAN(ent->v.velocity[i]))
 		{
-			Con_DPrintf ("Got a NaN velocity on %s\n", PR_GetString(ent->v.classname));
+			Con_DPrintf ("Got a NaN velocity on %s\n", PR_GetEntityString(ent->v.classname));
 			ent->v.velocity[i] = 0;
 		}
 		if (IS_NAN(ent->v.origin[i]))
 		{
-			Con_DPrintf ("Got a NaN origin on %s\n", PR_GetString(ent->v.classname));
+			Con_DPrintf ("Got a NaN origin on %s\n", PR_GetEntityString(ent->v.classname));
 			ent->v.origin[i] = 0;
 		}
 /*		if (ent->v.velocity[i] > sv_maxvelocity.value)

--- a/src/sv_phys.c
+++ b/src/sv_phys.c
@@ -1034,6 +1034,7 @@ void SV_RunBots(void)
 	if (sv.state != ss_active || !sv.physicstime)
 		return;
 
+#ifdef SERVERONLY
 	if (sv.old_bot_time)
 	{
 		// don't bother running a frame if 1/fps seconds haven't passed
@@ -1045,6 +1046,9 @@ void SV_RunBots(void)
 		sv_frametime = 1.0f / max_physfps; // initialization frame
 	}
 	sv.old_bot_time = sv.time;
+#else
+	// On internal server, we'll be matching the user's framerate
+#endif
 
 	savesvpl = sv_player;
 	savehc = sv_client;

--- a/src/sv_save.c
+++ b/src/sv_save.c
@@ -292,7 +292,8 @@ void SV_LoadGame_f (void) {
 		if (entnum == -1) {	
 			// parse the global vars
 			ED_ParseGlobals (start);
-		} else {	
+		}
+		else {	
 			// parse an edict
 			ent = EDICT_NUM(entnum);
 			ED_ClearEdict (ent); // FIXME: we also clear world edict here, is it OK?

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -163,7 +163,7 @@ void Con_Printf (char *fmt, ...)
 /*
 ================
 Con_DPrintf
- 
+
 A Con_Printf that only shows up if the "developer" cvar is set
 ================
 */
@@ -575,16 +575,15 @@ Larger attenuations will drop off.  (max 4 attenuation)
  
 ==================
 */
-void SV_StartSound (edict_t *entity, int channel, char *sample, int volume,
-                    float attenuation)
+void SV_StartSound (edict_t *entity, int channel, char *sample, int volume, float attenuation)
 {
-	int	sound_num;
-	int	field_mask;
-	int	i;
-	int	ent;
-	vec3_t	origin;
-	qbool	use_phs;
-	qbool	reliable = false;
+	int     sound_num;
+	int     field_mask;
+	int     i;
+	int     ent;
+	vec3_t  origin;
+	qbool   use_phs;
+	qbool   reliable = false;
 
 	if (volume < 0 || volume > 255)
 		SV_Error ("SV_StartSound: volume = %i", volume);
@@ -1115,7 +1114,7 @@ void SV_SendClientMessages (void)
 			SZ_Clear (&c->netchan.message);
 			SZ_Clear (&c->datagram);
 			c->num_backbuf = 0;
-			
+
 			// Need to tell mod what the bot would have seen
 			SV_SetVisibleEntitiesForBot (c);
 			continue;

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -822,7 +822,7 @@ void SV_UpdateClientStats (client_t *client)
 	}
 
 	stats[STAT_HEALTH] = ent->v.health;
-	stats[STAT_WEAPON] = SV_ModelIndex(PR_GetString(ent->v.weaponmodel));
+	stats[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v.weaponmodel));
 	stats[STAT_AMMO] = ent->v.currentammo;
 	stats[STAT_ARMOR] = ent->v.armorvalue;
 	stats[STAT_SHELLS] = ent->v.ammo_shells;
@@ -1199,7 +1199,7 @@ void MVD_WriteStats(void)
 		memset (stats, 0, sizeof(stats));
 
 		stats[STAT_HEALTH] = ent->v.health;
-		stats[STAT_WEAPON] = SV_ModelIndex(PR_GetString(ent->v.weaponmodel));
+		stats[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v.weaponmodel));
 		stats[STAT_AMMO] = ent->v.currentammo;
 		stats[STAT_ARMOR] = ent->v.armorvalue;
 		stats[STAT_SHELLS] = ent->v.ammo_shells;

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -1056,6 +1056,12 @@ void SV_SendClientMessages (void)
 	// update frags, names, etc
 	SV_UpdateToReliableMessages ();
 
+	if (fofs_visibility) {
+		for (i = 0; i < MAX_CLIENTS; ++i) {
+			((eval_t *)((byte *)&(svs.clients[i].edict)->v + fofs_visibility))->_int = 0;
+		}
+	}
+
 	// build individual updates
 	for (i=0, c = svs.clients ; i<MAX_CLIENTS ; i++, c++)
 	{
@@ -1109,6 +1115,9 @@ void SV_SendClientMessages (void)
 			SZ_Clear (&c->netchan.message);
 			SZ_Clear (&c->datagram);
 			c->num_backbuf = 0;
+			
+			// Need to tell mod what the bot would have seen
+			SV_SetVisibleEntitiesForBot (c);
 			continue;
 		}
 #endif

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -40,6 +40,7 @@ char	outputbuf[OUTPUTBUF_SIZE];
 redirect_t	sv_redirected;
 static int	sv_redirectbufcount;
 
+qbool SV_SkipCommsBotMessage(client_t* client);
 extern cvar_t sv_phs, sv_reliable_sound;
 
 /*
@@ -439,6 +440,8 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 		int trackent = 0;
 
 		if (client->state != cs_spawned)
+			continue;
+		if (SV_SkipCommsBotMessage(client))
 			continue;
 
 		if (!mask)
@@ -884,17 +887,19 @@ void SV_SendClientDatagram (client_t *client, int client_num)
 	}
 	*/
 
-	// add the client specific data to the datagram
-	SV_WriteClientdataToMessage (client, &msg);
+	if (!SV_SkipCommsBotMessage(client)) {
+		// add the client specific data to the datagram
+		SV_WriteClientdataToMessage(client, &msg);
 
-	// send over all the objects that are in the PVS
-	// this will include clients, a packetentities, and
-	// possibly a nails update
-	SV_WriteEntitiesToClient (client, &msg, false);
+		// send over all the objects that are in the PVS
+		// this will include clients, a packetentities, and
+		// possibly a nails update
+		SV_WriteEntitiesToClient(client, &msg, false);
 
 #ifdef FTE_PEXT2_VOICECHAT
-	SV_VoiceSendPacket(client, &msg);
+		SV_VoiceSendPacket(client, &msg);
 #endif
+	}
 
 	// copy the accumulated multicast datagram
 	// for this client out to the message

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -581,7 +581,6 @@ Larger attenuations will drop off.  (max 4 attenuation)
 void SV_StartSound (edict_t *entity, int channel, char *sample, int volume, float attenuation)
 {
 	int     sound_num;
-	int     field_mask;
 	int     i;
 	int     ent;
 	vec3_t  origin;
@@ -626,7 +625,6 @@ void SV_StartSound (edict_t *entity, int channel, char *sample, int volume, floa
 
 	channel = (ent<<3) | channel;
 
-	field_mask = 0;
 	if (volume != DEFAULT_SOUND_PACKET_VOLUME)
 		channel |= SND_VOLUME;
 	if (attenuation != DEFAULT_SOUND_PACKET_ATTENUATION)

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -703,7 +703,6 @@ int Sys_CreateThread(DWORD (WINAPI *func)(void *), void *param)
         CREATE_SUSPENDED,   // creation flags
         &threadid);         // pointer to receive thread ID
 
-    SetThreadPriority(thread, THREAD_PRIORITY_HIGHEST);
     ResumeThread(thread);
 
     return 1;

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -720,7 +720,6 @@ main
 int main(int ac, char *av[])
 {
 	double			newtime, time, oldtime;
-	int				j;
 	int				sleep_msec;
 
 	ParseCommandLine (ac, av);

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -351,6 +351,7 @@ void Sys_Quit (qbool restart)
 {
 	if (restart)
 	{
+#ifndef __MINGW32__
 		int maxfd = 131072; // well, should be enough for everyone...
 
 		_set_invalid_parameter_handler(myInvalidParameterHandler); // so close() does not crash our program on invalid handle...
@@ -363,6 +364,7 @@ void Sys_Quit (qbool restart)
 		}
 
 		if (execv(argv[0], com_argv) == -1)
+#endif
 		{
 #ifdef _CONSOLE
 			if (!((int)sys_nostdout.value || isdaemon))

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -2070,10 +2070,10 @@ static void Cmd_SetInfo_f (void)
 	if (sv_kickuserinfospamtime.value > 0 && (int)sv_kickuserinfospamcount.value > 0)
 	{
 		if (!sv_client->lastuserinfotime ||
-			realtime - sv_client->lastuserinfotime > sv_kickuserinfospamtime.value)
+			curtime - sv_client->lastuserinfotime > sv_kickuserinfospamtime.value)
 		{
 			sv_client->lastuserinfocount = 0;
-			sv_client->lastuserinfotime = realtime;
+			sv_client->lastuserinfotime = curtime;
 		}
 		else if (++(sv_client->lastuserinfocount) > (int)sv_kickuserinfospamcount.value)
 		{

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -276,7 +276,9 @@ static void Cmd_New_f (void)
 			SV_DropClient (sv_client);
 			return;
 		}
-		return;
+		if (!SV_SkipCommsBotMessage(sv_client)) {
+			return;
+		}
 	}
 #endif
 
@@ -602,6 +604,13 @@ static void Cmd_PreSpawn_f (void)
 			return;
 		}
 		sv_client->checksum = check;
+	}
+
+	if (SV_SkipCommsBotMessage(sv_client)) {
+		// skip pre-spawning
+		MSG_WriteByte (&sv_client->netchan.message, svc_stufftext);
+		MSG_WriteString (&sv_client->netchan.message, va("cmd spawn %i 0\n", svs.spawncount) );
+		return;
 	}
 
 	//NOTE:  This doesn't go through ClientReliableWrite since it's before the user

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -347,7 +347,7 @@ static void Cmd_New_f (void)
 	if (sv_client->rip_vip)
 		MSG_WriteString (&sv_client->netchan.message, "");
 	else
-		MSG_WriteString (&sv_client->netchan.message, PR_GetString(sv.edicts->v.message));
+		MSG_WriteString (&sv_client->netchan.message, PR_GetEntityString(sv.edicts->v.message));
 
 	// send the movevars
 	MSG_WriteFloat(&sv_client->netchan.message, movevars.gravity);
@@ -835,7 +835,7 @@ static void SV_SpawnSpectator (void)
 	for (i=MAX_CLIENTS-1 ; i<sv.num_edicts ; i++)
 	{
 		e = EDICT_NUM(i);
-		if (!strcmp(PR_GetString(e->v.classname), "info_player_start"))
+		if (!strcmp(PR_GetEntityString(e->v.classname), "info_player_start"))
 		{
 			VectorCopy (e->v.origin, sv_player->v.origin);
 			VectorCopy (e->v.angles, sv_player->v.angles);
@@ -2336,9 +2336,9 @@ void ProcessUserInfoChange (client_t* sv_client, const char* key, const char* ol
 	{
 		pr_global_struct->time = sv.time;
 		pr_global_struct->self = EDICT_TO_PROG(sv_client->edict);
-		G_INT(OFS_PARM0) = PR_SetTmpString(key);
-		G_INT(OFS_PARM1) = PR_SetTmpString(old_value);
-		G_INT(OFS_PARM2) = PR_SetTmpString(Info_Get(&sv_client->_userinfo_ctx_, key));
+		PR_SetTmpString(&G_INT(OFS_PARM0), key);
+		PR_SetTmpString(&G_INT(OFS_PARM1), old_value);
+		PR_SetTmpString(&G_INT(OFS_PARM2), Info_Get(&sv_client->_userinfo_ctx_, key));
 		PR_ExecuteProgram (mod_UserInfo_Changed);
 	}
 
@@ -2498,7 +2498,7 @@ static void SetUpClientEdict (client_t *cl, edict_t *ent)
 {
 	ED_ClearEdict(ent);
 	// restore client name.
-	ent->v.netname = PR_SetString(cl->name);
+	PR_SetEntityString(ent, ent->v.netname, cl->name);
 	// so spec will have right goalentity - if speccing someone
 	if(cl->spectator && cl->spec_track > 0)
 		ent->v.goalentity = EDICT_TO_PROG(svs.clients[cl->spec_track-1].edict);

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -304,6 +304,12 @@ static void Cmd_New_f (void)
 		MSG_WriteLong (&sv_client->netchan.message, sv_client->fteprotocolextensions2);
 	}
 #endif // PROTOCOL_VERSION_FTE2
+#ifdef PROTOCOL_VERSION_MVD1
+	if (sv_client->mvdprotocolextensions1) {
+		MSG_WriteLong (&sv_client->netchan.message, PROTOCOL_VERSION_MVD1);
+		MSG_WriteLong (&sv_client->netchan.message, sv_client->mvdprotocolextensions1);
+	}
+#endif
 	MSG_WriteLong  (&sv_client->netchan.message, PROTOCOL_VERSION);
 	MSG_WriteLong  (&sv_client->netchan.message, svs.spawncount);
 	MSG_WriteString(&sv_client->netchan.message, gamedir);
@@ -2890,6 +2896,17 @@ void Cmd_PEXT_f(void)
 			}
 			break;
 #endif // PROTOCOL_VERSION_FTE2
+
+#ifdef PROTOCOL_VERSION_MVD1
+		case PROTOCOL_VERSION_MVD1:
+			if (!sv_client->mvdprotocolextensions1)
+			{
+				sv_client->mvdprotocolextensions1 = proto_value & svs.mvdprotocolextension1;
+				if (sv_client->mvdprotocolextensions1)
+					Con_DPrintf("PEXT: Client supports 0x%x mvdsv extensions\n", sv_client->mvdprotocolextensions1);
+			}
+			break;
+#endif
 		}
 	}
 

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -470,15 +470,13 @@ static void Cmd_Modellist_f (void)
 	int         i;
 	unsigned    maxclientsupportedmodels;
 
-	if (sv_client->state != cs_connected)
-	{
+	if (sv_client->state != cs_connected) {
 		Con_Printf ("modellist not valid -- already spawned\n");
 		return;
 	}
 
 	// handle the case of a level changing while a client was connecting
-	if (Q_atoi(Cmd_Argv(1)) != svs.spawncount)
-	{
+	if (Q_atoi(Cmd_Argv(1)) != svs.spawncount) {
 		SV_ClearReliable (sv_client);
 		Con_Printf ("SV_Modellist_f from different level\n");
 		Cmd_New_f ();
@@ -486,11 +484,9 @@ static void Cmd_Modellist_f (void)
 	}
 
 	n = Q_atoi(Cmd_Argv(2));
-	if (n >= MAX_MODELS)
-	{
+	if (n >= MAX_MODELS) {
 		SV_ClearReliable (sv_client);
-		SV_ClientPrintf (sv_client, PRINT_HIGH,
-		                 "SV_Modellist_f: Invalid modellist index\n");
+		SV_ClientPrintf (sv_client, PRINT_HIGH, "SV_Modellist_f: Invalid modellist index\n");
 		SV_DropClient (sv_client);
 		return;
 	}
@@ -500,15 +496,16 @@ static void Cmd_Modellist_f (void)
 		char ss[1024] = "//vwep ";
 		// send VWep precaches
 		for (i = 0, s = sv.vw_model_name; i < MAX_VWEP_MODELS; s++, i++) {
-			if (!*s || !**s)
+			if (!*s || !**s) {
 				break;
-			if (i > 0)
-				strlcat (ss, " ", sizeof(ss));
-			strlcat (ss, TrimModelName(*s), sizeof(ss));
+			}
+			if (i > 0) {
+				strlcat(ss, " ", sizeof(ss));
+			}
+			strlcat(ss, TrimModelName(*s), sizeof(ss));
 		}
-		strlcat (ss, "\n", sizeof(ss));
-		if (ss[strlen(ss)-1] == '\n')		// didn't overflow?
-		{
+		strlcat(ss, "\n", sizeof(ss));
+		if (ss[strlen(ss) - 1] == '\n') {       // didn't overflow?
 			ClientReliableWrite_Begin (sv_client, svc_stufftext, 2 + strlen(ss));
 			ClientReliableWrite_String (sv_client, ss);
 		}
@@ -516,8 +513,7 @@ static void Cmd_Modellist_f (void)
 
 	//NOTE:  This doesn't go through ClientReliableWrite since it's before the user
 	//spawns.  These functions are written to not overflow
-	if (sv_client->num_backbuf)
-	{
+	if (sv_client->num_backbuf) {
 		Con_Printf("WARNING %s: [SV_Modellist] Back buffered (%d0), clearing\n", sv_client->name, sv_client->netchan.message.cursize);
 		sv_client->num_backbuf = 1;
 
@@ -699,7 +695,7 @@ static void Cmd_PreSpawn_f (void)
 		// need to prespawn more
 		MSG_WriteByte (&sv_client->netchan.message, svc_stufftext);
 		MSG_WriteString (&sv_client->netchan.message,
-			va("cmd prespawn %i %i\n", svs.spawncount, buf) );
+		                 va("cmd prespawn %i %i\n", svs.spawncount, buf) );
 	}
 }
 
@@ -710,9 +706,9 @@ Cmd_Spawn_f
 */
 static void Cmd_Spawn_f (void)
 {
-	int		i;
-	client_t	*client;
-	unsigned n;
+	int         i;
+	client_t    *client;
+	unsigned    n;
 
 	if (sv_client->state != cs_connected)
 	{
@@ -1016,7 +1012,7 @@ void SV_CompleteDownoload(void)
 	if (sv_client->spawncount != svs.spawncount)
 	{
 		char *str = "changing\n"
-					"reconnect\n";
+		            "reconnect\n";
 
 		ClientReliableWrite_Begin (sv_client, svc_stufftext, strlen(str)+2);
 		ClientReliableWrite_String (sv_client, str);
@@ -1104,11 +1100,11 @@ void SV_NextChunkedDownload(int chunknum, int percent, int chunked_download_numb
 
 static void Cmd_NextDownload_f (void)
 {
-	byte	buffer[FILE_TRANSFER_BUF_SIZE];
-	int		r, tmp;
-	int		percent;
-	int		size;
-	double	frametime;
+	byte    buffer[FILE_TRANSFER_BUF_SIZE];
+	int     r, tmp;
+	int     percent;
+	int     size;
+	double  frametime;
 
 	if (!sv_client->download)
 		return;
@@ -1184,7 +1180,7 @@ SV_NextUpload
 ==================
 */
 void SV_ReplaceChar(char *s, char from, char to);
-void SV_CancelUpload()
+void SV_CancelUpload(void)
 {
 	SV_ClientPrintf(sv_client, PRINT_HIGH, "Upload denied\n");
 	ClientReliableWrite_Begin (sv_client, svc_stufftext, 8);
@@ -1424,7 +1420,11 @@ static void Cmd_Download_f(void)
 	// techlogin download uses simple path from quake folder
 	if (sv_client->special)
 	{
+#ifdef SERVERONLY
 		sv_client->download = FS_OpenVFS(name, "rb", FS_GAME); // FIXME: Should we use FS_BASE ???
+#else
+		sv_client->download = FS_OpenVFS(name, "rb", FS_BASE); // FIXME: Should we use FS_BASE ???
+#endif
 		if (sv_client->download)
 		{
 			if ((int) developer.value)
@@ -1434,7 +1434,11 @@ static void Cmd_Download_f(void)
 	}
 	else
 	{
-		sv_client->download = FS_OpenVFS(name, "rb", FS_GAME);
+#ifdef SERVERONLY
+		sv_client->download = FS_OpenVFS(name, "rb", FS_GAME); // FIXME: Should we use FS_BASE ???
+#else
+		sv_client->download = FS_OpenVFS(name, "rb", FS_BASE); // FIXME: Should we use FS_BASE ???
+#endif
 		if (sv_client->download)
 			sv_client->downloadsize = VFS_GETLEN(sv_client->download);
 
@@ -1557,7 +1561,7 @@ static void Cmd_DemoDownload_f(void)
 			   Q_redtext(cmdhelp_dl), Q_redtext(cmdhelp_dot), Q_redtext(cmdhelp_dot), Q_redtext(cmdhelp_dot),
 			   Q_redtext(cmdhelp_dot), Q_redtext(cmdhelp_dot), Q_redtext(cmdhelp_dot),
 			   Q_redtext(cmdhelp_dl), Q_redtext(cmdhelp_bs), Q_redtext(cmdhelp_stop), Q_redtext(cmdhelp_cancel)
-		           );
+		);
 		return;
 	}
 
@@ -1665,12 +1669,12 @@ SV_Say
 
 static void SV_Say (qbool team)
 {
-	qbool	fake = false;
+	qbool    fake = false;
 	client_t *client;
-	int		j, tmp, cls = 0;
-	char	*p; // used basically for QC based mods.
-	char	text[2048] = ""; // used if mod does not have own support for say/say_team.
-	qbool	write_begin;
+	int      j, tmp, cls = 0;
+	char     *p;                  // used basically for QC based mods.
+	char     text[2048] = {0};    // used if mod does not have own support for say/say_team.
+	qbool    write_begin;
 
 	if (Cmd_Argc () < 2)
 		return;
@@ -1782,16 +1786,12 @@ static void SV_Say (qbool team)
 					; // send msg to self anyway
 				else if (client->spectator)
 				{
-					if(   !sv_sayteam_to_spec.value // player can't say_team to spec in this case
-					   || !fake // self say_team does't contain $\ so this is treat as private message
-					   || (   client->spec_track <= 0
-						   && strcmp(sv_client->team, client->team)
-						  ) // spec do not track player and on different team
-					   || (   client->spec_track  > 0
-						   && strcmp(sv_client->team, svs.clients[client->spec_track - 1].team)
-						  ) // spec track player on different team
-					  )
-					continue;	// on different teams
+					if( !sv_sayteam_to_spec.value // player can't say_team to spec in this case
+					    || !fake // self say_team does't contain $\ so this is treat as private message
+					    || (client->spec_track <= 0 && strcmp(sv_client->team, client->team)) // spec do not track player and on different team
+					    || (client->spec_track > 0 && strcmp(sv_client->team, svs.clients[client->spec_track - 1].team)) // spec track player on different team
+					)
+						continue;	// on different teams
 				}
 				else if (coop.value)
 					; // allow team messages to everyone in coop from players.
@@ -2243,7 +2243,7 @@ static void Cmd_SetInfo_f (void)
 
 	pr_global_struct->time = sv.time;
 	pr_global_struct->self = EDICT_TO_PROG(sv_player);
-	if(PR_UserInfoChanged())
+	if (PR_UserInfoChanged())
 		return; // does not allowed to be changed by mod.
 
 	Info_Set (&sv_client->_userinfo_ctx_, Cmd_Argv(1), Cmd_Argv(2));
@@ -2268,7 +2268,7 @@ static void Cmd_SetInfo_f (void)
 		}
 		//<-
 		//VVD: forcenick ->
-		if ((int)sv_forcenick.value && (int)sv_login.value && sv_client->login)
+		if ((int)sv_forcenick.value && (int)sv_login.value && sv_client->login[0])
 		{
 			SV_ClientPrintf(sv_client, PRINT_CHAT,
 			                "You can't change your name while logged in on this server.\n");
@@ -2590,7 +2590,7 @@ static void Cmd_Join_f (void)
 	pr_global_struct->self = EDICT_TO_PROG(sv_player);
 	G_FLOAT(OFS_PARM0) = (float) sv_client->vip;
 	PR_GameClientConnect(0);
-	
+
 	// actually spawn the player
 	pr_global_struct->time = sv.time;
 	pr_global_struct->self = EDICT_TO_PROG(sv_player);
@@ -2667,7 +2667,7 @@ static void Cmd_Observe_f (void)
 	PR_GameSetNewParms();
 
 	SV_SpawnSpectator ();
-	
+
 	// copy spawn parms out of the client_t
 	for (i=0 ; i<NUM_SPAWN_PARMS ; i++)
 		sv_client->spawn_parms[i] = (&PR_GLOBAL(parm1))[i];
@@ -2712,12 +2712,12 @@ struct
 {
 	struct voice_ring_s
 	{
-			unsigned int sender;
-			unsigned char receiver[MAX_CLIENTS/8];
-			unsigned char gen;
-			unsigned char seq;
-			unsigned int datalen;
-			unsigned char data[1024];
+		unsigned int sender;
+		unsigned char receiver[MAX_CLIENTS/8];
+		unsigned char gen;
+		unsigned char seq;
+		unsigned int datalen;
+		unsigned char data[1024];
 	} ring[VOICE_RING_SIZE];
 	unsigned int write;
 } voice;
@@ -3313,7 +3313,11 @@ void SV_RunCmd (usercmd_t *ucmd, qbool inside, qbool second_attempt) //bliP: 24/
 	int tmp_time;
 	int blocked;
 
-	if (!inside && (int)sv_speedcheck.value && !sv_client->isBot)
+	if (!inside && (int)sv_speedcheck.value
+#ifdef USE_PR2
+		&& !sv_client->isBot
+#endif
+	)
 	{
 		/* AM101 method */
 		tmp_time = Q_rint((realtime - sv_client->last_check) * 1000); // ie. Old 'timepassed'
@@ -3383,7 +3387,7 @@ void SV_RunCmd (usercmd_t *ucmd, qbool inside, qbool second_attempt) //bliP: 24/
 	ucmd->angles[PITCH] = bound(sv_minpitch.value, ucmd->angles[PITCH], sv_maxpitch.value);
 	if (!sv_player->v.fixangle && ! second_attempt)
 		VectorCopy (ucmd->angles, sv_player->v.v_angle);
-	
+
 	// model angles
 	// show 1/3 the pitch angle and all the roll angle
 	if (sv_player->v.health > 0)
@@ -3473,6 +3477,7 @@ FIXME
 	// do the move
 	blocked = PM_PlayerMove ();
 
+#ifdef USE_PR2
 	// This is a temporary hack for Frogbots, who adjust after bumping into things
 	// Better would be to provide a way to simulate a move command, but at least this doesn't require API change
 	if (blocked && !second_attempt && sv_client->isBot && sv_player->v.blocked)
@@ -3497,6 +3502,7 @@ FIXME
 		SV_RunCmd (ucmd, false, true);
 		return;
 	}
+#endif
 
 	// get player state back out of pmove
 	sv_client->jump_held = pmove.jump_held;
@@ -3800,9 +3806,15 @@ void SV_ExecuteClientMessage (client_t *cl)
 			}*/
 			//<-
 
+#ifndef SERVERONLY
+			MSG_ReadDeltaUsercmd (&nullcmd, &oldest, PROTOCOL_VERSION);
+			MSG_ReadDeltaUsercmd (&oldest, &oldcmd, PROTOCOL_VERSION);
+			MSG_ReadDeltaUsercmd (&oldcmd, &newcmd, PROTOCOL_VERSION);
+#else
 			MSG_ReadDeltaUsercmd (&nullcmd, &oldest);
 			MSG_ReadDeltaUsercmd (&oldest, &oldcmd);
 			MSG_ReadDeltaUsercmd (&oldcmd, &newcmd);
+#endif
 
 			if ( cl->state != cs_spawned )
 				break;

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -3037,7 +3037,7 @@ void Cmd_PEXT_f(void)
 	MSG_WriteString (&sv_client->netchan.message, "cmd new\n");
 }
 
-#ifdef SERVERONLY
+#if defined(SERVERONLY) && defined(WWW_INTEGRATION)
 // { Central login
 void Cmd_Login_f(void)
 {
@@ -3115,7 +3115,7 @@ void SV_Noclip_f (void);
 void SV_Fly_f (void);
 // }
 
-#ifdef SERVERONLY
+#if defined(SERVERONLY) && defined(WWW_INTEGRATION)
 // { central login
 void Cmd_Login_f(void);
 void Cmd_Logout_f(void);
@@ -3205,7 +3205,7 @@ static ucmd_t ucmds[] =
 
 	{"pext", Cmd_PEXT_f, false}, // user reply with supported protocol extensions.
 
-#ifdef SERVERONLY
+#if defined(SERVERONLY) && defined(WWW_INTEGRATION)
 	{"login", Cmd_Login_f, false},
 	{"login-response", Cmd_ChallengeResponse_f, false},
 	{"logout", Cmd_Logout_f, false},

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -3037,6 +3037,7 @@ void Cmd_PEXT_f(void)
 	MSG_WriteString (&sv_client->netchan.message, "cmd new\n");
 }
 
+#ifdef SERVERONLY
 // { Central login
 void Cmd_Login_f(void)
 {
@@ -3090,7 +3091,7 @@ void Cmd_Logout_f(void)
 	sv_client->logged = 0;
 }
 // } Central login
-
+#endif
 
 void SV_DemoList_f(void);
 void SV_DemoListRegex_f(void);
@@ -3114,11 +3115,13 @@ void SV_Noclip_f (void);
 void SV_Fly_f (void);
 // }
 
+#ifdef SERVERONLY
 // { central login
 void Cmd_Login_f(void);
 void Cmd_Logout_f(void);
 void Cmd_ChallengeResponse_f(void);
 // }
+#endif
 
 typedef struct
 {
@@ -3202,9 +3205,11 @@ static ucmd_t ucmds[] =
 
 	{"pext", Cmd_PEXT_f, false}, // user reply with supported protocol extensions.
 
+#ifdef SERVERONLY
 	{"login", Cmd_Login_f, false},
 	{"login-response", Cmd_ChallengeResponse_f, false},
 	{"logout", Cmd_Logout_f, false},
+#endif
 
 	{NULL, NULL}
 };

--- a/src/version.h
+++ b/src/version.h
@@ -62,8 +62,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 
 #define	QW_VERSION			"2.40"
-#define VERSION_NUMBER		"0.31"
-#define VERSION_NUM			0.31
+#define VERSION_NUMBER		"0.32-dev.1"
+#define VERSION_NUM			0.32
 #define SERVER_NAME			"MVDSV"
 
 #define PROJECT_NAME		SERVER_NAME

--- a/src/vfs_pak.c
+++ b/src/vfs_pak.c
@@ -222,7 +222,7 @@ static void FSPAK_BuildHash(void *handle)
 static qbool FSPAK_FLocate(void *handle, flocation_t *loc, const char *filename, void *hashedresult)
 {
 	packfile_t *pf = hashedresult;
-	int i, len;
+	int i;
 	pack_t		*pak = handle;
 
 // look through all the pak file elements
@@ -246,7 +246,6 @@ static qbool FSPAK_FLocate(void *handle, flocation_t *loc, const char *filename,
 
 	if (pf)
 	{
-		len = pf->filelen;
 		if (loc)
 		{
 			loc->index = pf - pak->files;

--- a/src/world.c
+++ b/src/world.c
@@ -300,7 +300,7 @@ static void SV_TouchLinks ( edict_t *ent, areanode_t *node )
 	edict_t		*touchlist[MAX_EDICTS], *touch;
 	int			old_self, old_other;
 
-	numtouch = SV_AreaEdicts (ent->v.absmin, ent->v.absmax, touchlist, MAX_EDICTS, AREA_TRIGGERS);
+	numtouch = SV_AreaEdicts (ent->v.absmin, ent->v.absmax, touchlist, sv.max_edicts, AREA_TRIGGERS);
 
 // touch linked edicts
 	for (i = 0; i < numtouch; i++)
@@ -523,7 +523,7 @@ void SV_ClipToLinks ( areanode_t *node, moveclip_t *clip )
 	edict_t		*touchlist[MAX_EDICTS], *touch;
 	trace_t		trace;
 
-	numtouch = SV_AreaEdicts (clip->boxmins, clip->boxmaxs, touchlist, MAX_EDICTS, AREA_SOLID);
+	numtouch = SV_AreaEdicts (clip->boxmins, clip->boxmaxs, touchlist, sv.max_edicts, AREA_SOLID);
 
 // touch linked edicts
 	for (i = 0; i < numtouch; i++)

--- a/src/world.c
+++ b/src/world.c
@@ -671,7 +671,7 @@ void SV_AntilagClipCheck ( areanode_t *node, moveclip_t *clip )
 		if (touch == clip->passedict)
 			continue;
 		if (touch->v.solid == SOLID_TRIGGER)
-			SV_Error ("Trigger (%s) in clipping list", PR_GetString(touch->v.classname));
+			SV_Error ("Trigger (%s) in clipping list", PR_GetEntityString(touch->v.classname));
 
 		if ((clip->type & MOVE_NOMONSTERS) && touch->v.solid != SOLID_BSP)
 			continue;

--- a/src/world.c
+++ b/src/world.c
@@ -484,24 +484,24 @@ trace_t SV_ClipMoveToEntity (edict_t *ent, vec3_t *eorg, vec3_t start, vec3_t mi
 	vec3_t		start_l, end_l;
 	hull_t		*hull;
 
-// get the clipping hull
+	// get the clipping hull
 	hull = SV_HullForEntity (ent, mins, maxs, offset);
 
-// { well, its hack for sv_antilag
+	// { well, its hack for sv_antilag
 	if (eorg)
 		VectorCopy((*eorg), offset);
-// }
+	// }
 
 	VectorSubtract (start, offset, start_l);
 	VectorSubtract (end, offset, end_l);
 
-// trace a line through the apropriate clipping hull
+	// trace a line through the apropriate clipping hull
 	trace = CM_HullTrace (hull, start_l, end_l);
 
-// fix trace up by the offset
+	// fix trace up by the offset
 	VectorAdd (trace.endpos, offset, trace.endpos);
 
-// did we clip the move?
+	// did we clip the move?
 	if (trace.fraction < 1 || trace.startsolid)
 		trace.e.ent = ent;
 
@@ -525,7 +525,7 @@ void SV_ClipToLinks ( areanode_t *node, moveclip_t *clip )
 
 	numtouch = SV_AreaEdicts (clip->boxmins, clip->boxmaxs, touchlist, sv.max_edicts, AREA_SOLID);
 
-// touch linked edicts
+	// touch linked edicts
 	for (i = 0; i < numtouch; i++)
 	{
 		// might intersect, so do an exact clip
@@ -719,7 +719,6 @@ void SV_AntilagClipCheck ( areanode_t *node, moveclip_t *clip )
 	}
 }
 
-
 /*
 ==================
 SV_Trace
@@ -772,4 +771,3 @@ trace_t SV_Trace (vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int type, 
 
 	return clip.trace;
 }
-

--- a/src/zone.c
+++ b/src/zone.c
@@ -1,22 +1,21 @@
 /*
 Copyright (C) 1996-1997 Id Software, Inc.
- 
+
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2
 of the License, or (at your option) any later version.
- 
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
- 
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
 See the GNU General Public License for more details.
- 
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- 
-	
+
 */
 // zone.c - memory management
 
@@ -26,15 +25,14 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "common.h"
 #endif
 
-void Cache_FreeLow (int new_low_hunk);
-void Cache_FreeHigh (int new_high_hunk);
+void Cache_FreeLow(int new_low_hunk);
+void Cache_FreeHigh(int new_high_hunk);
 
 //============================================================================
 
-#define	HUNK_SENTINEL	0x1df001ed
+#define	HUNK_SENTINEL 0x1df001ed
 
-typedef struct
-{
+typedef struct {
 	int		sentinel;
 	int		size; // including sizeof(hunk_t), -1 = not allocated
 	char	name[8];
@@ -56,34 +54,35 @@ Hunk_Check
 Run consistency and sentinel trashing checks
 ==============
 */
-void Hunk_Check (void)
+void Hunk_Check(void)
 {
-	hunk_t	*h;
+	hunk_t *h;
 
-	for (h = (hunk_t *)hunk_base ; (byte *)h != hunk_base + hunk_low_used ; )
-	{
-		if (h->sentinel != HUNK_SENTINEL)
-			Sys_Error ("Hunk_Check: trashed sentinel");
-		if (h->size < 16 || h->size + (byte *)h - hunk_base > hunk_size)
-			Sys_Error ("Hunk_Check: bad size");
-		h = (hunk_t *)((byte *)h+h->size);
+	for (h = (hunk_t *)hunk_base; (byte *)h != hunk_base + hunk_low_used;) {
+		if (h->sentinel != HUNK_SENTINEL) {
+			Sys_Error("Hunk_Check: trashed sentinel");
+		}
+		if (h->size < 16 || h->size + (byte *)h - hunk_base > hunk_size) {
+			Sys_Error("Hunk_Check: bad size");
+		}
+		h = (hunk_t *)((byte *)h + h->size);
 	}
 }
 
 /*
 ==============
 Hunk_Print
- 
+
 If "all" is specified, every single allocation is printed.
 Otherwise, allocations with the same name will be totaled up before printing.
 ==============
 */
-void Hunk_Print (qbool all)
+void Hunk_Print(qbool all)
 {
-	hunk_t	*h, *next, *endlow, *starthigh, *endhigh;
-	int	count, sum;
-	int	totalblocks;
-	char	name[9];
+	hunk_t  *h, *next, *endlow, *starthigh, *endhigh;
+	int     count, sum;
+	int     totalblocks;
+	char    name[9];
 
 	name[8] = 0;
 	count = 0;
@@ -95,55 +94,47 @@ void Hunk_Print (qbool all)
 	starthigh = (hunk_t *)(hunk_base + hunk_size - hunk_high_used);
 	endhigh = (hunk_t *)(hunk_base + hunk_size);
 
-	Con_Printf ("          :%8i total hunk size\n", hunk_size);
-	Con_Printf ("-------------------------\n");
+	Con_Printf("          :%8i total hunk size\n", hunk_size);
+	Con_Printf("-------------------------\n");
 
-	while (1)
-	{
-		//
+	while (1) {
 		// skip to the high hunk if done with low hunk
-		//
-		if ( h == endlow )
-		{
-			Con_Printf ("-------------------------\n");
-			Con_Printf ("          :%8i REMAINING\n", hunk_size - hunk_low_used - hunk_high_used);
-			Con_Printf ("-------------------------\n");
+		if (h == endlow) {
+			Con_Printf("-------------------------\n");
+			Con_Printf("          :%8i REMAINING\n", hunk_size - hunk_low_used - hunk_high_used);
+			Con_Printf("-------------------------\n");
 			h = starthigh;
 		}
 
-		//
 		// if totally done, break
-		//
-		if ( h == endhigh )
+		if (h == endhigh) {
 			break;
+		}
 
-		//
 		// run consistency checks
-		//
-		if (h->sentinel != HUNK_SENTINEL)
-			Sys_Error ("Hunk_Check: trashed sentinel");
-		if (h->size < 16 || h->size + (byte *)h - hunk_base > hunk_size)
-			Sys_Error ("Hunk_Check: bad size");
+		if (h->sentinel != HUNK_SENTINEL) {
+			Sys_Error("Hunk_Print: trashed sentinel");
+		}
+		if (h->size < 16 || h->size + (byte *)h - hunk_base > hunk_size) {
+			Sys_Error("Hunk_Print: bad size");
+		}
 
-		next = (hunk_t *)((byte *)h+h->size);
+		next = (hunk_t *)((byte *)h + h->size);
 		count++;
 		totalblocks++;
 		sum += h->size;
 
-		//
 		// print the single block
-		//
-		memcpy (name, h->name, 8);
-		if (all)
-			Con_Printf ("%8p :%8i %8s\n", h, h->size, name);
+		memcpy(name, h->name, 8);
+		if (all) {
+			Con_Printf("%8p :%8i %8s\n", h, h->size, name);
+		}
 
-		//
 		// print the total
-		//
-		if (next == endlow || next == endhigh || strncmp (h->name, next->name, 8) )
-		{
-			if (!all)
-				Con_Printf ("          :%8i %8s (TOTAL)\n", sum, name);
+		if (next == endlow || next == endhigh || strncmp(h->name, next->name, 8)) {
+			if (!all) {
+				Con_Printf("          :%8i %8s (TOTAL)\n", sum, name);
+			}
 			count = 0;
 			sum = 0;
 		}
@@ -151,11 +142,11 @@ void Hunk_Print (qbool all)
 		h = next;
 	}
 
-	Con_Printf ("-------------------------\n");
-	Con_Printf ("%8i total blocks\n", totalblocks);
+	Con_Printf("-------------------------\n");
+	Con_Printf("%8i total blocks\n", totalblocks);
 }
 
-void Hunk_Print_f (void)
+void Hunk_Print_f(void)
 {
 	qbool all = Cmd_Argc() != 1;
 
@@ -167,34 +158,40 @@ void Hunk_Print_f (void)
 Hunk_AllocName
 ===================
 */
-void *Hunk_AllocName (int size, char *name)
+void *Hunk_AllocName(int size, char *name)
 {
-	hunk_t	*h;
+	hunk_t *h;
 
 #ifdef PARANOID
-	Hunk_Check ();
+	Hunk_Check();
 #endif
 
-	if (size < 0)
-		Sys_Error ("Hunk_AllocName: bad size: %i", size);
+	if (size < 0) {
+		Sys_Error("Hunk_AllocName: bad size: %i", size);
+	}
 
 	size = sizeof(hunk_t) + ((size + 15) & ~15);
 
-	if (hunk_size - hunk_low_used - hunk_high_used < size)
-		Sys_Error ("Hunk_AllocName: Not enough RAM allocated. Try starting using \"-mem 64 (or more)\" on the command line.");
+	if (hunk_size - hunk_low_used - hunk_high_used < size) {
+#ifdef SERVERONLY
+		Sys_Error("Hunk_AllocName: Not enough RAM allocated. Try starting using \"-mem 64\" (or more) on the command line.");
+#else
+		Sys_Error("Hunk_AllocName: Not enough RAM allocated. Try starting using \"-mem 128\" (or more) on the command line.");
+#endif
+	}
 
 	h = (hunk_t *)(hunk_base + hunk_low_used);
 	hunk_low_used += size;
 
-	Cache_FreeLow (hunk_low_used);
+	Cache_FreeLow(hunk_low_used);
 
-	memset (h, 0, size);
+	memset(h, 0, size);
 
 	h->size = size;
 	h->sentinel = HUNK_SENTINEL;
-	strlcpy (h->name, name, sizeof (h->name));
+	strlcpy(h->name, name, sizeof(h->name));
 
-	return (void *) (h + 1);
+	return (void *)(h + 1);
 }
 
 /*
@@ -202,89 +199,92 @@ void *Hunk_AllocName (int size, char *name)
 Hunk_Alloc
 ===================
 */
-void *Hunk_Alloc (int size)
+void *Hunk_Alloc(int size)
 {
-	return Hunk_AllocName (size, "unknown");
+	return Hunk_AllocName(size, "unknown");
 }
 
-int	Hunk_LowMark (void)
+int	Hunk_LowMark(void)
 {
 	return hunk_low_used;
 }
 
-void Hunk_FreeToLowMark (int mark)
+void Hunk_FreeToLowMark(int mark)
 {
-	if (mark < 0 || mark > hunk_low_used)
-		Sys_Error ("Hunk_FreeToLowMark: bad mark %i, hunk_low_used = %i", mark, hunk_low_used);
-	memset (hunk_base + mark, 0, hunk_low_used - mark);
+	if (mark < 0 || mark > hunk_low_used) {
+		Sys_Error("Hunk_FreeToLowMark: bad mark %i, hunk_low_used = %i", mark, hunk_low_used);
+	}
+	memset(hunk_base + mark, 0, hunk_low_used - mark);
 	hunk_low_used = mark;
 }
 
-int	Hunk_HighMark (void)
+int	Hunk_HighMark(void)
 {
-	if (hunk_tempactive)
-	{
+	if (hunk_tempactive) {
 		hunk_tempactive = false;
-		Hunk_FreeToHighMark (hunk_tempmark);
+		Hunk_FreeToHighMark(hunk_tempmark);
 	}
 
 	return hunk_high_used;
 }
 
-void Hunk_FreeToHighMark (int mark)
+void Hunk_FreeToHighMark(int mark)
 {
-	if (hunk_tempactive)
-	{
+	if (hunk_tempactive) {
 		hunk_tempactive = false;
-		Hunk_FreeToHighMark (hunk_tempmark);
+		Hunk_FreeToHighMark(hunk_tempmark);
 	}
-	if (mark < 0 || mark > hunk_high_used)
-		Sys_Error ("Hunk_FreeToHighMark: bad mark %i", mark);
-	memset (hunk_base + hunk_size - hunk_high_used, 0, hunk_high_used - mark);
+	if (mark < 0 || mark > hunk_high_used) {
+		Sys_Error("Hunk_FreeToHighMark: bad mark %i", mark);
+	}
+	memset(hunk_base + hunk_size - hunk_high_used, 0, hunk_high_used - mark);
 	hunk_high_used = mark;
 }
-
 
 /*
 ===================
 Hunk_HighAllocName
 ===================
 */
-void *Hunk_HighAllocName (int size, char *name)
+void *Hunk_HighAllocName(int size, char *name)
 {
-	hunk_t	*h;
+	hunk_t *h;
 
-	if (size < 0)
-		Sys_Error ("Hunk_HighAllocName: bad size: %i", size);
+	if (size < 0) {
+		Sys_Error("Hunk_HighAllocName: bad size: %i", size);
+	}
 
-	if (hunk_tempactive)
-	{
-		Hunk_FreeToHighMark (hunk_tempmark);
+	if (hunk_tempactive) {
+		Hunk_FreeToHighMark(hunk_tempmark);
 		hunk_tempactive = false;
 	}
 
 #ifdef PARANOID
-	Hunk_Check ();
+	Hunk_Check();
 #endif
 
-	size = sizeof(hunk_t) + ((size+15)&~15);
+	size = sizeof(hunk_t) + ((size + 15)&~15);
 
-	if (hunk_size - hunk_low_used - hunk_high_used < size)
-		Sys_Error ("Hunk_HighAllocName: Not enough RAM allocated. Try starting using \"-mem 64 (or more)\" on the command line.");
+	if (hunk_size - hunk_low_used - hunk_high_used < size) {
+#ifdef SERVERONLY
+		Sys_Error("Hunk_HighAllocName: Not enough RAM allocated. Try starting using \"-mem 64\" (or more) on the command line.");
+#else
+		Sys_Error("Hunk_HighAllocName: Not enough RAM allocated. Try starting using \"-mem 128\" (or more) on the command line.");
+#endif
+	}
 
 	hunk_high_used += size;
-	Cache_FreeHigh (hunk_high_used);
+	Cache_FreeHigh(hunk_high_used);
 
 	h = (hunk_t *)(hunk_base + hunk_size - hunk_high_used);
 
-	memset (h, 0, size);
+	memset(h, 0, size);
 	h->size = size;
 	h->sentinel = HUNK_SENTINEL;
-	strlcpy (h->name, name, sizeof (h->name));
+	strlcpy(h->name, name, sizeof(h->name));
 
-	return (void *) (h + 1);
+	return (void *)(h + 1);
 }
-
 
 /*
 =================
@@ -293,21 +293,20 @@ Hunk_TempAlloc
 Return space from the top of the hunk
 =================
 */
-void *Hunk_TempAlloc (int size)
+void *Hunk_TempAlloc(int size)
 {
-	void	*buf;
+	void *buf;
 
-	size = (size+15) & ~15;
+	size = (size + 15) & ~15;
 
-	if (hunk_tempactive)
-	{
-		Hunk_FreeToHighMark (hunk_tempmark);
+	if (hunk_tempactive) {
+		Hunk_FreeToHighMark(hunk_tempmark);
 		hunk_tempactive = false;
 	}
 
-	hunk_tempmark = Hunk_HighMark ();
+	hunk_tempmark = Hunk_HighMark();
 
-	buf = Hunk_HighAllocName (size, "temp");
+	buf = Hunk_HighAllocName(size, "temp");
 
 	hunk_tempactive = true;
 
@@ -322,8 +321,7 @@ CACHE MEMORY
 ===============================================================================
 */
 
-typedef struct cache_system_s
-{
+typedef struct cache_system_s {
 	int						size; // including this header
 	cache_user_t			*user;
 	char					name[16];
@@ -331,91 +329,91 @@ typedef struct cache_system_s
 	struct cache_system_s	*lru_prev, *lru_next; // for LRU flushing
 } cache_system_t;
 
-cache_system_t *Cache_TryAlloc (int size, qbool nobottom);
+cache_system_t *Cache_TryAlloc(int size, qbool nobottom);
 
-cache_system_t	cache_head;
+cache_system_t cache_head;
 
 /*
 ===========
 Cache_Move
 ===========
 */
-void Cache_Move ( cache_system_t *c)
+void Cache_Move(cache_system_t *c)
 {
-	cache_system_t *nuw;
+	cache_system_t *new_block;
 
 	// we are clearing up space at the bottom, so only allocate it late
-	nuw = Cache_TryAlloc (c->size, true);
-	if (nuw)
-	{
-		memcpy ( nuw+1, c+1, c->size - sizeof(cache_system_t) );
-		nuw->user = c->user;
-		memcpy (nuw->name, c->name, sizeof(nuw->name));
-		Cache_Free (c->user);
-		nuw->user->data = (void *)(nuw+1);
+	new_block = Cache_TryAlloc(c->size, true);
+	if (new_block) {
+		memcpy(new_block + 1, c + 1, c->size - sizeof(cache_system_t));
+		new_block->user = c->user;
+		memcpy(new_block->name, c->name, sizeof(new_block->name));
+		Cache_Free(c->user);
+		new_block->user->data = (void *)(new_block + 1);
 	}
-	else
-	{
-		// cache move failed
-		Cache_Free (c->user);		// tough luck...
+	else {
+		Cache_Free(c->user); // tough luck...
 	}
 }
 
 /*
 ============
 Cache_FreeLow
- 
+
 Throw things out until the hunk can be expanded to the given point
 ============
 */
-void Cache_FreeLow (int new_low_hunk)
+void Cache_FreeLow(int new_low_hunk)
 {
-	cache_system_t	*c;
+	cache_system_t *c;
 
-	while (1)
-	{
+	while (1) {
 		c = cache_head.next;
-		if (c == &cache_head)
-			return;		// nothing in cache at all
-		if ((byte *)c >= hunk_base + new_low_hunk)
-			return;		// there is space to grow the hunk
-		Cache_Move ( c );	// reclaim the space
+		if (c == &cache_head) {
+			return;	// nothing in cache at all
+		}
+		if ((byte *)c >= hunk_base + new_low_hunk) {
+			return; // there is space to grow the hunk
+		}
+		Cache_Move(c); // reclaim the space
 	}
 }
 
 /*
 ============
 Cache_FreeHigh
- 
+
 Throw things out until the hunk can be expanded to the given point
 ============
 */
-void Cache_FreeHigh (int new_high_hunk)
+void Cache_FreeHigh(int new_high_hunk)
 {
-	cache_system_t	*c, *prev;
+	cache_system_t *c, *prev;
 
 	prev = NULL;
-	while (1)
-	{
+	while (1) {
 		c = cache_head.prev;
-		if (c == &cache_head)
-			return;		// nothing in cache at all
-		if ( (byte *)c + c->size <= hunk_base + hunk_size - new_high_hunk)
-			return;		// there is space to grow the hunk
-		if (c == prev)
-			Cache_Free (c->user);	// didn't move out of the way
-		else
-		{
-			Cache_Move (c);	// try to move it
+		if (c == &cache_head) {
+			return; // nothing in cache at all
+		}
+		if ((byte *)c + c->size <= hunk_base + hunk_size - new_high_hunk) {
+			return;	// there is space to grow the hunk
+		}
+		if (c == prev) {
+			Cache_Free(c->user); // didn't move out of the way
+		}
+		else {
+			Cache_Move(c); // try to move it
 			prev = c;
 		}
 	}
 }
 
-void Cache_UnlinkLRU (cache_system_t *cs)
+void Cache_UnlinkLRU(cache_system_t *cs)
 {
-	if (!cs->lru_next || !cs->lru_prev)
-		Sys_Error ("Cache_UnlinkLRU: NULL link");
+	if (!cs->lru_next || !cs->lru_prev) {
+		Sys_Error("Cache_UnlinkLRU: NULL link");
+	}
 
 	cs->lru_next->lru_prev = cs->lru_prev;
 	cs->lru_prev->lru_next = cs->lru_next;
@@ -423,10 +421,11 @@ void Cache_UnlinkLRU (cache_system_t *cs)
 	cs->lru_prev = cs->lru_next = NULL;
 }
 
-void Cache_MakeLRU (cache_system_t *cs)
+void Cache_MakeLRU(cache_system_t *cs)
 {
-	if (cs->lru_next || cs->lru_prev)
-		Sys_Error ("Cache_MakeLRU: active link");
+	if (cs->lru_next || cs->lru_prev) {
+		Sys_Error("Cache_MakeLRU: active link");
+	}
 
 	cache_head.lru_next->lru_prev = cs;
 	cs->lru_next = cache_head.lru_next;
@@ -437,131 +436,126 @@ void Cache_MakeLRU (cache_system_t *cs)
 /*
 ============
 Cache_TryAlloc
- 
+
 Looks for a free block of memory between the high and low hunk marks
 Size should already include the header and padding
 ============
 */
-cache_system_t *Cache_TryAlloc (int size, qbool nobottom)
+cache_system_t *Cache_TryAlloc(int size, qbool nobottom)
 {
-	cache_system_t	*cs, *nuw;
+	cache_system_t *cs, *new_block;
 
 	// is the cache completely empty?
+	if (!nobottom && cache_head.prev == &cache_head) {
+		if (hunk_size - hunk_high_used - hunk_low_used < size) {
+			Sys_Error("Cache_TryAlloc: %i is greater than free hunk", size);
+		}
 
-	if (!nobottom && cache_head.prev == &cache_head)
-	{
-		if (hunk_size - hunk_high_used - hunk_low_used < size)
-			Sys_Error ("Cache_TryAlloc: %i is greater then free hunk", size);
+		new_block = (cache_system_t *)(hunk_base + hunk_low_used);
+		memset(new_block, 0, sizeof(*new_block));
+		new_block->size = size;
 
-		nuw = (cache_system_t *) (hunk_base + hunk_low_used);
-		memset (nuw, 0, sizeof(*nuw));
-		nuw->size = size;
+		cache_head.prev = cache_head.next = new_block;
+		new_block->prev = new_block->next = &cache_head;
 
-		cache_head.prev = cache_head.next = nuw;
-		nuw->prev = nuw->next = &cache_head;
-
-		Cache_MakeLRU (nuw);
-		return nuw;
+		Cache_MakeLRU(new_block);
+		return new_block;
 	}
 
 	// search from the bottom up for space
-	nuw = (cache_system_t *) (hunk_base + hunk_low_used);
+	new_block = (cache_system_t *)(hunk_base + hunk_low_used);
 	cs = cache_head.next;
 
-	do
-	{
-		if (!nobottom || cs != cache_head.next)
-		{
-			if ( (byte *)cs - (byte *)nuw >= size)
-			{	// found space
-				memset (nuw, 0, sizeof(*nuw));
-				nuw->size = size;
+	do {
+		if (!nobottom || cs != cache_head.next) {
+			if ((byte *)cs - (byte *)new_block >= size) {
+				// found space
+				memset(new_block, 0, sizeof(*new_block));
+				new_block->size = size;
 
-				nuw->next = cs;
-				nuw->prev = cs->prev;
-				cs->prev->next = nuw;
-				cs->prev = nuw;
+				new_block->next = cs;
+				new_block->prev = cs->prev;
+				cs->prev->next = new_block;
+				cs->prev = new_block;
 
-				Cache_MakeLRU (nuw);
+				Cache_MakeLRU(new_block);
 
-				return nuw;
+				return new_block;
 			}
 		}
 
 		// continue looking
-		nuw = (cache_system_t *)((byte *)cs + cs->size);
+		new_block = (cache_system_t *)((byte *)cs + cs->size);
 		cs = cs->next;
-
 	} while (cs != &cache_head);
 
 	// try to allocate one at the very end
-	if ( hunk_base + hunk_size - hunk_high_used - (byte *)nuw >= size)
-	{
-		memset (nuw, 0, sizeof(*nuw));
-		nuw->size = size;
+	if (hunk_base + hunk_size - hunk_high_used - (byte *)new_block >= size) {
+		memset(new_block, 0, sizeof(*new_block));
+		new_block->size = size;
 
-		nuw->next = &cache_head;
-		nuw->prev = cache_head.prev;
-		cache_head.prev->next = nuw;
-		cache_head.prev = nuw;
+		new_block->next = &cache_head;
+		new_block->prev = cache_head.prev;
+		cache_head.prev->next = new_block;
+		cache_head.prev = new_block;
 
-		Cache_MakeLRU (nuw);
+		Cache_MakeLRU(new_block);
 
-		return nuw;
+		return new_block;
 	}
 
-	return NULL;		// couldn't allocate
+	return NULL; // couldn't allocate
 }
 
 /*
 ============
 Cache_Flush
- 
+
 Throw everything out, so new data will be demand cached
 ============
 */
-void Cache_Flush (void)
+void Cache_Flush(void)
 {
-	while (cache_head.next != &cache_head)
-		Cache_Free ( cache_head.next->user );	// reclaim the space
+	while (cache_head.next != &cache_head) {
+		Cache_Free(cache_head.next->user); // reclaim the space
+	}
 }
 
 /*
 ============
 Cache_Print
- 
+
 ============
 */
-void Cache_Print (void)
+void Cache_Print(void)
 {
-	cache_system_t	*cd;
+	cache_system_t *cd;
 
-	for (cd = cache_head.next ; cd != &cache_head ; cd = cd->next)
-	{
-		Con_Printf ("%8i : %s\n", cd->size, cd->name);
+	for (cd = cache_head.next; cd != &cache_head; cd = cd->next) {
+		Con_Printf("%5.1f kB : %s\n", (cd->size / (float)(1024)), cd->name);
 	}
 }
 
 /*
 ============
 Cache_Report
- 
+
 ============
 */
-void Cache_Report (void)
+void Cache_Report(void)
 {
-	Con_Printf ("%4.1f of %4.1f megabyte data cache free\n",
-		(float)(hunk_size - hunk_high_used - hunk_low_used) / (1024*1024),
-		(float)hunk_size / (1024*1024));
+	Con_Printf("%4.1f of %4.1f megabyte data cache free\n",
+		(float)(hunk_size - hunk_high_used - hunk_low_used) / (1024 * 1024),
+		(float)hunk_size / (1024 * 1024));
 }
 
 /*
 ============
 Cache_Init
- 
+
 ============
 */
-void Cache_Init (void)
+void Cache_Init(void)
 {
 	cache_head.next = cache_head.prev = &cache_head;
 	cache_head.lru_next = cache_head.lru_prev = &cache_head;
@@ -572,35 +566,30 @@ void Cache_Init (void)
 #endif
 }
 
-/*
-============
-Cache_Init
- 
-============
-*/
-void Cache_Init_Commands (void)
+void Cache_Init_Commands(void)
 {
-	Cmd_AddCommand ("flush", Cache_Flush);
-	Cmd_AddCommand ("cache_print", Cache_Print);
-	Cmd_AddCommand ("cache_report", Cache_Report);
+	Cmd_AddCommand("flush", Cache_Flush);
+	Cmd_AddCommand("cache_print", Cache_Print);
+	Cmd_AddCommand("cache_report", Cache_Report);
 
-	Cmd_AddCommand ("hunk_print", Hunk_Print_f);
+	Cmd_AddCommand("hunk_print", Hunk_Print_f);
 }
 
 #ifndef WITH_DP_MEM
 /*
 ==============
 Cache_Free
- 
+
 Frees the memory and removes it from the LRU list
 ==============
 */
-void Cache_Free (cache_user_t *c)
+void Cache_Free(cache_user_t *c)
 {
-	cache_system_t	*cs;
+	cache_system_t *cs;
 
-	if (!c->data)
-		Sys_Error ("Cache_Free: not allocated");
+	if (!c->data) {
+		Sys_Error("Cache_Free: not allocated");
+	}
 
 	cs = ((cache_system_t *)c->data) - 1;
 
@@ -610,7 +599,7 @@ void Cache_Free (cache_user_t *c)
 
 	c->data = NULL;
 
-	Cache_UnlinkLRU (cs);
+	Cache_UnlinkLRU(cs);
 }
 
 /*
@@ -618,18 +607,19 @@ void Cache_Free (cache_user_t *c)
 Cache_Check
 ==============
 */
-void *Cache_Check (cache_user_t *c)
+void *Cache_Check(cache_user_t *c)
 {
-	cache_system_t	*cs;
+	cache_system_t *cs;
 
-	if (!c->data)
+	if (!c->data) {
 		return NULL;
+	}
 
 	cs = ((cache_system_t *)c->data) - 1;
 
 	// move to head of LRU
-	Cache_UnlinkLRU (cs);
-	Cache_MakeLRU (cs);
+	Cache_UnlinkLRU(cs);
+	Cache_MakeLRU(cs);
 
 	return c->data;
 }
@@ -639,38 +629,40 @@ void *Cache_Check (cache_user_t *c)
 Cache_Alloc
 ==============
 */
-void *Cache_Alloc (cache_user_t *c, int size, char *name)
+void *Cache_Alloc(cache_user_t *c, int size, char *name)
 {
-	cache_system_t	*cs;
+	cache_system_t *cs;
 
-	if (c->data)
-		Sys_Error ("Cache_Alloc: already allocated");
+	if (c->data) {
+		Sys_Error("Cache_Alloc: already allocated");
+	}
 
-	if (size <= 0)
-		Sys_Error ("Cache_Alloc: size %i", size);
+	if (size <= 0) {
+		Sys_Error("Cache_Alloc: size %i", size);
+	}
 
 	size = (size + sizeof(cache_system_t) + 15) & ~15;
 
 	// find memory for it
-	while (1)
-	{
-		cs = Cache_TryAlloc (size, false);
-		if (cs)
-		{
-			strlcpy (cs->name, name, sizeof(cs->name));
-			c->data = (void *)(cs+1);
+	while (1) {
+		cs = Cache_TryAlloc(size, false);
+		if (cs) {
+			strlcpy(cs->name, name, sizeof(cs->name));
+			c->data = (void *)(cs + 1);
 			cs->user = c;
 			break;
 		}
 
 		// free the least recently used cahedat
-		if (cache_head.lru_prev == &cache_head)
-			Sys_Error ("Cache_Alloc: out of memory");
+		if (cache_head.lru_prev == &cache_head) {
+			Sys_Error("Cache_Alloc: out of memory");
+		}
+
 		// not enough memory at all
-		Cache_Free ( cache_head.lru_prev->user );
+		Cache_Free(cache_head.lru_prev->user);
 	}
 
-	return Cache_Check (c);
+	return Cache_Check(c);
 }
 #endif
 //============================================================================
@@ -680,13 +672,12 @@ void *Cache_Alloc (cache_user_t *c, int size, char *name)
 Memory_Init
 ========================
 */
-void Memory_Init (void *buf, int size)
+void Memory_Init(void *buf, int size)
 {
-	hunk_base = (byte *) buf;
+	hunk_base = (byte *)buf;
 	hunk_size = size;
 	hunk_low_used = 0;
 	hunk_high_used = 0;
 
-	Cache_Init ();
+	Cache_Init();
 }
-

--- a/src/zone.h
+++ b/src/zone.h
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
-	
 */
 #ifndef __ZONE_H__
 #define __ZONE_H__


### PR DESCRIPTION
## MVDSV 0.32 Changelist

- Support for BSP2 and BSP29a file formats (increased map limits)
- Protocol extension MVD_PEXT1_FLOATCOORDS - for player & entities only (not explosions etc)
- Userinfo spam protection uses realtime not gametime (don't kick players for userinfo spam when paused)
- Connected QTV servers can be listed through the disconnected "status" command
- Connected QTV observers can be listed through the disconnected "qtvusers" command
- Exposes which players players & entities were sent to the client to the mod
- Supports 'hideplayers' field from mod - if set players not sent (used for KTX race mode)
- Support for communicating with central web server
- Fixed long-standing issue with edict_t being different size in 32 & 64 bit builds.  Still not 100% PR1 compatible though.
- `/qtv_sayenabled 1` allows qtv chat even when demo being recorded (used for KTX race mode)
- `/sv_serveme_fix` option to allow [ServeMe] bot to communicate when `/sv_bigcoords 1` set
- Uses monotonic clock_gettime instead of gettimeofday on *nix systems
- Misc fixes for PR2 bots to run