### PR TITLE
add meson build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,100 @@
+project('mvdsv', 'c')
+
+mvdsv_sources = [
+	'src/bothtools.c',
+	'src/build.c',
+	'src/cmd.c',
+	'src/cmodel.c',
+	'src/common.c',
+	'src/crc.c',
+	'src/cvar.c',
+	'src/fs.c',
+	'src/hash.c',
+	'src/mathlib.c',
+	'src/md4.c',
+	'src/net.c',
+	'src/net_chan.c',
+	'src/pmove.c',
+	'src/pmovetst.c',
+	'src/pr2_cmds.c',
+	'src/pr2_edict.c',
+	'src/pr2_exec.c',
+	'src/pr2_vm.c',
+	'src/pr_cmds.c',
+	'src/pr_edict.c',
+	'src/pr_exec.c',
+	'src/sha1.c',
+	'src/sv_ccmds.c',
+	'src/sv_demo.c',
+	'src/sv_demo_misc.c',
+	'src/sv_demo_qtv.c',
+	'src/sv_ents.c',
+	'src/sv_init.c',
+	'src/sv_login.c',
+	'src/sv_main.c',
+	'src/sv_master.c',
+	'src/sv_mod_frags.c',
+	'src/sv_move.c',
+	'src/sv_nchan.c',
+	'src/sv_phys.c',
+	'src/sv_save.c',
+	'src/sv_send.c',
+	'src/sv_user.c',
+	'src/vfs_os.c',
+	'src/vfs_pak.c',
+	'src/world.c',
+	'src/zone.c',
+]
+
+deps = [
+	dependency('threads')
+]
+
+pcre = dependency('libpcre', required : false)
+if pcre.found()
+	deps += pcre
+else
+	mvdsv_sources += [
+		'src/pcre/get.c',
+		'src/pcre/pcre.c'
+	]
+endif
+
+link_args = []
+
+if target_machine.system() == 'windows'
+	mvdsv_sources += [
+		'src/sv_sys_win.c',
+		'src/sv_windows.c',
+		import('windows').compile_resources('src/winquake.rc')
+	]
+	deps += [
+		meson.get_compiler('c').find_library('ws2_32'),
+		meson.get_compiler('c').find_library('winmm'),
+	]
+	if meson.get_compiler('c').get_id() == 'gcc'
+		link_args += '-static-libgcc'
+	endif
+else
+	mvdsv_sources += 'src/sv_sys_unix.c'
+	deps += [
+		meson.get_compiler('c').find_library('m'),
+		meson.get_compiler('c').find_library('dl'),
+	]
+endif
+
+c_args = ['-DSERVERONLY', '-DUSE_PR2']
+
+if target_machine.endian() == 'little'
+	c_args += '-D__LITTLE_ENDIAN__Q__'
+elif target_machine.endian() == 'big'
+	c_args += '-D__BIG_ENDIAN__Q__'
+else
+	c_args += '-D__PDP_ENDIAN__Q__'
+endif
+
+executable('mvdsv', mvdsv_sources,
+	dependencies : deps,
+	c_args : c_args,
+	link_args : link_args
+)


### PR DESCRIPTION
In an effort to get rid of cumbersome Makefiles or other custom configure things. Tested for native targets Linux, macOS and Windows/MSYS2. Cross compile tested from Linux -> Windows.

It actually tries to detect if you have libpcre installed and links to that library in case you have it. If not it will just compile the pcre files in the repository. Might be nice to not maintain those but rely on system installed libs. Keep in mind though that deployment then may require copying the libpcre library as well.

No ASM support for now. Mingw targets need to prevent `#define id386` in `quakeasm.h` unless someone knows how to compile these `.s` files nowadays.

Here is a linux -> mingw cross-compile example config for a 64 bit target (e.g. mingw.txt):
```
[binaries]
c = 'x86_64-w64-mingw32-gcc'
cpp = 'x86_64-w64-mingw32-g++'
ar = 'x86_64-w64-mingw32-ar'
strip = 'x86_64-w64-mingw32-strip'
pkgconfig = 'x86_64-w64-mingw32-pkg-config'
windres = 'x86_64-w64-mingw32-windres'

[host_machine]
system = 'windows'
cpu_family = 'x86_64'
cpu = 'x86_64'
endian = 'little'
```
Compile commands would be:
```
meson --buildtype=release --cross-file=mingw.txt mingw
ninja -C mingw
```

Native builds should just drop the `--cross-file` option:
```
meson --buildtype=release build
ninja -C build
```

Debug builds would just drop the `--buildtype` option:
```
meson debug
ninja -C debug
```