### PR TITLE
MINGW: proper checks for < VS2015

### DIFF
--- a/src/bothtools.c
+++ b/src/bothtools.c
@@ -217,8 +217,7 @@ float Q_atof (const char *str)
 	return str;
 }*/
 
-#ifdef _WIN32
-#if !defined(_MSC_VER) || (_MSC_VER < 1900)
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
 int snprintf(char *buffer, size_t count, char const *format, ...)
 {
 	int ret;
@@ -231,7 +230,6 @@ int snprintf(char *buffer, size_t count, char const *format, ...)
 	return ret;
 }
 #endif // !(Visual Studio 2015+)
-#endif
 
 #if defined(_MSC_VER) && (_MSC_VER < 1400)
 int vsnprintf(char *buffer, size_t count, const char *format, va_list argptr)


### PR DESCRIPTION
Fix the check for VS version smaller than VS2015. This fixes a mingw build error.

The _WIN32 check is no needed as this is implied by _MSC_VER. And actually it should similar as it is done with vsnprintf below.
