### PR TITLE
don't enable ASM on Windows x86_64

### DIFF
--- a/src/quakeasm.h
+++ b/src/quakeasm.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #ifndef __QUAKEASM_H__
 #define __QUAKEASM_H__
 
-#if (defined _WIN32 && !defined id386)
+#if (defined _WIN32 && !defined _WIN64 && !defined id386)
 #define id386
 #endif
 


### PR DESCRIPTION
Since the ASM code is for x86 only, don't force it on Windows x86_64.