### PR TITLE
remove server part of edict_t from mod memory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,12 @@ else
 	c_args += '-D__PDP_ENDIAN__Q__'
 endif
 
+if target_machine.cpu_family() == 'x86_64' 
+	c_args += '-Didx64'
+elif target_machine.cpu_family() == 'x86' 
+	c_args += '-Did386'
+endif
+
 if target_machine.cpu_family() == 'x86' and target_machine.system() != 'darwin'
 	asm_c_args = ['-x', 'assembler-with-cpp', '-Did386']
 	if target_machine.system() != 'windows'

--- a/src/bothdefs.h
+++ b/src/bothdefs.h
@@ -219,6 +219,8 @@ float	FloatSwapPDP2Lit (float f);
 //============================================================================
 
 #ifdef _WIN32
+#undef strcasecmp
+#undef strncasecmp
 #define strcasecmp(s1, s2) _stricmp  ((s1),   (s2))
 #define strncasecmp(s1, s2, n) _strnicmp ((s1),   (s2),   (n))
 int		snprintf(char *str, size_t n, char const *fmt, ...);

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -2535,9 +2535,9 @@ void PF2_Add_Bot( byte * base, uintptr_t mask, pr2val_t * stack, pr2val_t * retv
 	if ( val )
 		val->_float = 1.0;
 	sv_client->maxspeed = sv_maxspeed.value;
-	val = PR2_GetEdictFieldValue( ent, "maxspeed" );
-	if ( val )
-		val->_float = sv_maxspeed.value;
+
+	if (fofs_maxspeed)
+		EdictFieldFloat(ent, fofs_maxspeed) = (int)sv_maxspeed.value;
 
 	newcl->edict = ent;
 	ent->v->colormap = edictnum;

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -304,7 +304,9 @@ bprint(value)
 */
 void PF2_bprint(byte* base, uintptr_t mask, pr2val_t* stack, pr2val_t*retval)
 {
-	SV_BroadcastPrintfEx(stack[0]._int, stack[2]._int, "%s", VM_POINTER(base,mask,stack[1].string));
+    int flags = stack[2]._int;
+    if( gamedata.APIversion < 15 ) flags = 0;
+	SV_BroadcastPrintfEx(stack[0]._int, flags, "%s", VM_POINTER(base,mask,stack[1].string));
 }
 
 /*
@@ -2643,6 +2645,7 @@ void PF2_SetBotUserInfo( byte * base, uintptr_t mask, pr2val_t * stack, pr2val_t
 	int     i;
 	extern char *shortinfotbl[];
 
+    if( gamedata.APIversion < 15 ) flags = 0;
 	if (strstr(key, "&c") || strstr(key, "&r") || strstr(value, "&c") || strstr(value, "&r"))
 		return;
 

--- a/src/pr2_edict.c
+++ b/src/pr2_edict.c
@@ -36,7 +36,7 @@ eval_t *PR2_GetEdictFieldValue(edict_t *ed, char *field)
 
 	for (f = fields; (s = PR2_GetString(f->name)) && *s; f++)
 		if (!strcasecmp(PR2_GetString(f->name), field))
-			return (eval_t *)((char *) ed + f->ofs);
+			return (eval_t *)((char *) ed->v + f->ofs);
 
 	return NULL;
 }
@@ -51,7 +51,7 @@ int ED2_FindFieldOffset (char *field)
 
 	for (f = fields; (s = PR2_GetString(f->name)) && *s; f++)
 		if (!strcasecmp(PR2_GetString(f->name), field))
-			return f->ofs-((int)&(((edict_t *)0)->v));
+			return f->ofs;//((int)&(((edict_t *)0)->v));
 
 	return 0;
 }

--- a/src/pr2_edict.c
+++ b/src/pr2_edict.c
@@ -36,7 +36,7 @@ eval_t *PR2_GetEdictFieldValue(edict_t *ed, char *field)
 
 	for (f = fields; (s = PR2_GetString(f->name)) && *s; f++)
 		if (!strcasecmp(PR2_GetString(f->name), field))
-			return (eval_t *)((char *) ed->v + f->ofs);
+			return (eval_t *)((char *) ed->v + f->ofs - pr_edict_offset);
 
 	return NULL;
 }
@@ -51,7 +51,7 @@ int ED2_FindFieldOffset (char *field)
 
 	for (f = fields; (s = PR2_GetString(f->name)) && *s; f++)
 		if (!strcasecmp(PR2_GetString(f->name), field))
-			return f->ofs;//((int)&(((edict_t *)0)->v));
+			return f->ofs - pr_edict_offset;//((int)&(((edict_t *)0)->v));
 
 	return 0;
 }

--- a/src/pr_edict.c
+++ b/src/pr_edict.c
@@ -31,6 +31,7 @@ dstatement_t	*pr_statements;
 globalvars_t	*pr_global_struct;
 float			*pr_globals;			// same as pr_global_struct
 int				pr_edict_size;	// in bytes
+int				pr_edict_offset;	// in bytes
 
 #define NQ_PROGHEADER_CRC 5927
 
@@ -91,9 +92,9 @@ Sets everything to NULL
 */
 void ED_ClearEdict (edict_t *e)
 {
-	memset(&e->v, 0, pr_edict_size - sizeof(edict_t) + sizeof(entvars_t));
-	e->e->lastruntime = 0;
-	e->e->free = false;
+	memset(e->v, 0, pr_edict_size - pr_edict_offset);
+	e->e.lastruntime = 0;
+	e->e.free = false;
 	PR_ClearEdict(e);
 }
 
@@ -118,7 +119,7 @@ edict_t *ED_Alloc (void)
 		e = EDICT_NUM(i);
 		// the first couple seconds of server time can involve a lot of
 		// freeing and allocating, so relax the replacement policy
-		if (e->e->free && (e->e->freetime < 2 || sv.time - e->e->freetime > 0.5))
+		if (e->e.free && (e->e.freetime < 2 || sv.time - e->e.freetime > 0.5))
 		{
 			ED_ClearEdict(e);
 			return e;
@@ -155,21 +156,21 @@ void ED_Free (edict_t *ed)
 {
 	SV_UnlinkEdict (ed);		// unlink from world bsp
 
-	ed->e->free = true;
-	ed->v.model = 0;
-	ed->v.takedamage = 0;
-	ed->v.modelindex = 0;
-	ed->v.colormap = 0;
-	ed->v.skin = 0;
-	ed->v.frame = 0;
-	ed->v.health = 0;
-	ed->v.classname = 0;
-	VectorClear (ed->v.origin);
-	VectorClear (ed->v.angles);
-	ed->v.nextthink = -1;
-	ed->v.solid = 0;
+	ed->e.free = true;
+	ed->v->model = 0;
+	ed->v->takedamage = 0;
+	ed->v->modelindex = 0;
+	ed->v->colormap = 0;
+	ed->v->skin = 0;
+	ed->v->frame = 0;
+	ed->v->health = 0;
+	ed->v->classname = 0;
+	VectorClear (ed->v->origin);
+	VectorClear (ed->v->angles);
+	ed->v->nextthink = -1;
+	ed->v->solid = 0;
 
-	ed->e->freetime = sv.time;
+	ed->e.freetime = sv.time;
 }
 
 //===========================================================================
@@ -323,7 +324,7 @@ Done:
 	if (!def)
 		return NULL;
 
-	return (eval_t *)((char *)&ed->v + def->ofs*4);
+	return (eval_t *)((char *)ed->v + def->ofs*4);
 }
 
 /*
@@ -499,7 +500,7 @@ void ED_Print (edict_t *ed)
 	char	*name;
 	int		type;
 
-	if (ed->e->free)
+	if (ed->e.free)
 	{
 		Con_Printf ("FREE\n");
 		return;
@@ -512,7 +513,7 @@ void ED_Print (edict_t *ed)
 		if (name[strlen(name)-2] == '_')
 			continue;	// skip _x, _y, _z vars
 
-		v = (int *)((char *)&ed->v + d->ofs*4);
+		v = (int *)((char *)ed->v + d->ofs*4);
 
 		// if the value is still all 0, skip the field
 		type = d->type & ~DEF_SAVEGLOBAL;
@@ -549,7 +550,7 @@ void ED_Write (FILE *f, edict_t *ed)
 
 	fprintf (f, "{\n");
 
-	if (ed->e->free)
+	if (ed->e.free)
 	{
 		fprintf (f, "}\n");
 		return;
@@ -562,7 +563,7 @@ void ED_Write (FILE *f, edict_t *ed)
 		if (name[strlen(name)-2] == '_')
 			continue;	// skip _x, _y, _z vars
 
-		v = (int *)((char *)&ed->v + d->ofs*4);
+		v = (int *)((char *)ed->v + d->ofs*4);
 
 		// if the value is still all 0, skip the field
 		type = d->type & ~DEF_SAVEGLOBAL;
@@ -648,14 +649,14 @@ void ED_Count (void)
 	for (i=0 ; i<sv.num_edicts ; i++)
 	{
 		ent = EDICT_NUM(i);
-		if (ent->e->free)
+		if (ent->e.free)
 			continue;
 		active++;
-		if (ent->v.solid)
+		if (ent->v->solid)
 			solid++;
-		if (ent->v.model)
+		if (ent->v->model)
 			models++;
-		if (ent->v.movetype == MOVETYPE_STEP)
+		if (ent->v->movetype == MOVETYPE_STEP)
 			step++;
 	}
 
@@ -931,12 +932,12 @@ char *ED_ParseEdict (char *data, edict_t *ent)
 			snprintf (com_token, MAX_COM_TOKEN, "0 %s 0", temp);
 		}
 
-		if (!ED_ParseEpair ((void *)&ent->v, key, com_token))
+		if (!ED_ParseEpair ((void *)ent->v, key, com_token))
 			SV_Error ("ED_ParseEdict: parse error");
 	}
 
 	if (!init)
-		ent->e->free = true;
+		ent->e.free = true;
 
 	return data;
 }
@@ -986,16 +987,16 @@ void ED_LoadFromFile (char *data)
 		// remove things from different skill levels or deathmatch
 		if ((int)deathmatch.value)
 		{
-			if (((int)ent->v.spawnflags & SPAWNFLAG_NOT_DEATHMATCH))
+			if (((int)ent->v->spawnflags & SPAWNFLAG_NOT_DEATHMATCH))
 			{
 				ED_Free (ent);
 				inhibit++;
 				continue;
 			}
 		}
-		else if ((current_skill == 0 && ((int)ent->v.spawnflags & SPAWNFLAG_NOT_EASY))
-		         || (current_skill == 1 && ((int)ent->v.spawnflags & SPAWNFLAG_NOT_MEDIUM))
-		         || (current_skill >= 2 && ((int)ent->v.spawnflags & SPAWNFLAG_NOT_HARD)) )
+		else if ((current_skill == 0 && ((int)ent->v->spawnflags & SPAWNFLAG_NOT_EASY))
+		         || (current_skill == 1 && ((int)ent->v->spawnflags & SPAWNFLAG_NOT_MEDIUM))
+		         || (current_skill >= 2 && ((int)ent->v->spawnflags & SPAWNFLAG_NOT_HARD)) )
 		{
 			ED_Free (ent);
 			inhibit++;
@@ -1005,7 +1006,7 @@ void ED_LoadFromFile (char *data)
 		//
 		// immediately call spawn function
 		//
-		if (!ent->v.classname)
+		if (!ent->v->classname)
 		{
 			Con_Printf ("No classname for:\n");
 			ED_Print (ent);
@@ -1014,7 +1015,7 @@ void ED_LoadFromFile (char *data)
 		}
 
 		// look for the spawn function
-		func = ED_FindFunction ( PR1_GetString(ent->v.classname) );
+		func = ED_FindFunction ( PR1_GetString(ent->v->classname) );
 
 		if (!func)
 		{
@@ -1182,7 +1183,8 @@ void PR1_LoadProgs (void)
 	pr_global_struct = (globalvars_t *)((byte *)progs + progs->ofs_globals);
 	pr_globals = (float *)pr_global_struct;
 
-	pr_edict_size = progs->entityfields * 4 + sizeof (edict_t) - sizeof(entvars_t);
+	pr_edict_size = progs->entityfields * 4;
+    pr_edict_offset = 0;
 
 	// byte swap the lumps
 	for (i = 0; i < progs->numstatements; i++)
@@ -1227,7 +1229,7 @@ void PR1_LoadProgs (void)
 
 void PR1_InitProg(void)
 {
-	sv.edicts = (edict_t*) Hunk_AllocName (MAX_EDICTS * pr_edict_size, "edicts");
+	sv.game_edicts = (entvars_t*) Hunk_AllocName (MAX_EDICTS * pr_edict_size, "edicts");
 	sv.max_edicts = MAX_EDICTS;
 }
 
@@ -1255,7 +1257,7 @@ edict_t *EDICT_NUM(int n)
 {
 	if (n < 0 || n >= sv.max_edicts)
 		SV_Error ("EDICT_NUM: bad number %i", n);
-	return (edict_t *)((byte *)sv.edicts+ (n)*pr_edict_size);
+	return &sv.edicts[n];
 }
 
 int NUM_FOR_EDICT(edict_t *e)
@@ -1263,7 +1265,8 @@ int NUM_FOR_EDICT(edict_t *e)
 	int		b;
 
 	b = (byte *)e - (byte *)sv.edicts;
-	b /= pr_edict_size;
+	b /= sizeof( edict_t);
+    b = e->e.entnum;
 
 	if (b < 0 || b >= sv.num_edicts)
 		SV_Error ("NUM_FOR_EDICT: bad pointer");

--- a/src/pr_exec.c
+++ b/src/pr_exec.c
@@ -545,11 +545,11 @@ void PR_ExecuteProgram (func_t fnum)
 		case OP_STOREP_FLD:		// integers
 		case OP_STOREP_S:
 		case OP_STOREP_FNC:		// pointers
-			ptr = (eval_t *)((byte *)sv.edicts + b->_int);
+			ptr = (eval_t *)((byte *)sv.game_edicts + b->_int);
 			ptr->_int = a->_int;
 			break;
 		case OP_STOREP_V:
-			ptr = (eval_t *)((byte *)sv.edicts + b->_int);
+			ptr = (eval_t *)((byte *)sv.game_edicts + b->_int);
 			ptr->vector[0] = a->vector[0];
 			ptr->vector[1] = a->vector[1];
 			ptr->vector[2] = a->vector[2];
@@ -562,7 +562,7 @@ void PR_ExecuteProgram (func_t fnum)
 #endif
 			if (ed == (edict_t *)sv.edicts && sv.state == ss_active)
 				PR_RunError ("assignment to world entity");
-			c->_int = (byte *)((int *)&ed->v + PR_FIELDOFS(b->_int)) - (byte *)sv.edicts;
+			c->_int = (byte *)((int *)ed->v + PR_FIELDOFS(b->_int)) - (byte *)sv.game_edicts;
 			break;
 
 		case OP_LOAD_F:
@@ -577,7 +577,7 @@ void PR_ExecuteProgram (func_t fnum)
 			//need for checking 'cmd mmode player N', if N >= 0x10000000 =(signed)=> negative
 			if (b->_int >= 0)
 			{
-				a = (eval_t *)((int *)&ed->v + PR_FIELDOFS(b->_int));
+				a = (eval_t *)((int *)ed->v + PR_FIELDOFS(b->_int));
 				c->_int = a->_int;
 			}
 			else
@@ -589,7 +589,7 @@ void PR_ExecuteProgram (func_t fnum)
 #ifdef PARANOID
 			NUM_FOR_EDICT(ed);		// make sure it's in range
 #endif
-			a = (eval_t *)((int *)&ed->v + PR_FIELDOFS(b->_int));
+			a = (eval_t *)((int *)ed->v + PR_FIELDOFS(b->_int));
 			c->vector[0] = a->vector[0];
 			c->vector[1] = a->vector[1];
 			c->vector[2] = a->vector[2];
@@ -652,12 +652,12 @@ void PR_ExecuteProgram (func_t fnum)
 
 		case OP_STATE:
 			ed = PROG_TO_EDICT(pr_global_struct->self);
-			ed->v.nextthink = pr_global_struct->time + 0.1;
-			if (a->_float != ed->v.frame)
+			ed->v->nextthink = pr_global_struct->time + 0.1;
+			if (a->_float != ed->v->frame)
 			{
-				ed->v.frame = a->_float;
+				ed->v->frame = a->_float;
 			}
-			ed->v.think = b->function;
+			ed->v->think = b->function;
 			break;
 
 		default:

--- a/src/progs.h
+++ b/src/progs.h
@@ -65,11 +65,11 @@ typedef struct sv_edict_s
 
 typedef struct edict_s
 {
-	sv_edict_t	*e;			// server side part of the edict_t,
+	sv_edict_t	e;			// server side part of the edict_t,
 							// basically we can get rid of this pointer at all, since we can access it via sv.sv_edicts[num]
 							// but this way it more friendly, I think.
 
-	entvars_t	v;			// C exported fields from progs
+	entvars_t	*v;			// C exported fields from progs
 	// other fields from progs come immediately after
 } edict_t;
 
@@ -85,6 +85,7 @@ extern	globalvars_t	*pr_global_struct;
 extern	float		*pr_globals;	// same as pr_global_struct
 
 extern	int         pr_edict_size;	// in bytes
+extern  int			pr_edict_offset;	// in bytes
 extern	cvar_t      sv_progsname; 
 #ifdef WITH_NQPROGS
 extern	cvar_t      sv_forcenqprogs;
@@ -142,25 +143,25 @@ void ED_LoadFromFile (char *data);
 edict_t *EDICT_NUM(int n);
 int NUM_FOR_EDICT(edict_t *e);
 
-#define	NEXT_EDICT(e) ((edict_t *)( (byte *)e + pr_edict_size))
+#define	NEXT_EDICT(e) ((edict_t *)( (byte *)e + sizeof(edict_t)))
 
-#define	EDICT_TO_PROG(e) ((byte *)e - (byte *)sv.edicts)
-#define PROG_TO_EDICT(e) ((edict_t *)((byte *)sv.edicts + e))
+#define	EDICT_TO_PROG(e) ((byte *)(e->v) - ( (byte *)sv.game_edicts  ))
+#define PROG_TO_EDICT(e) (&sv.edicts[(e)/pr_edict_size])
 
 //============================================================================
 
 #define	G_FLOAT(o) (pr_globals[o])
 #define	G_INT(o) (*(int *)&pr_globals[o])
-#define	G_EDICT(o) ((edict_t *)((byte *)sv.edicts+ *(int *)&pr_globals[o]))
+#define	G_EDICT(o) (&sv.edicts[(*(int *)&pr_globals[o]  )/pr_edict_size])
 #define G_EDICTNUM(o) NUM_FOR_EDICT(G_EDICT(o))
 #define	G_VECTOR(o) (&pr_globals[o])
 #define	G_STRING(o) (PR1_GetString(*(string_t *)&pr_globals[o]))
 #define	G_FUNCTION(o) (*(func_t *)&pr_globals[o])
 
-#define	E_FLOAT(e,o) (((float*)&e->v)[o])
-#define	E_INT(e,o) (*(int *)&((float*)&e->v)[o])
-#define	E_VECTOR(e,o) (&((float*)&e->v)[o])
-#define	E_STRING(e,o) (PR1_GetString(*(string_t *)&((float*)&e->v)[PR_FIELDOFS(o)]))
+#define	E_FLOAT(e,o) (((float*)e->v)[o])
+#define	E_INT(e,o) (*(int *)&((float*)e->v)[o])
+#define	E_VECTOR(e,o) (&((float*)e->v)[o])
+#define	E_STRING(e,o) (PR1_GetString(*(string_t *)&((float*)e->v)[PR_FIELDOFS(o)]))
 
 extern	int		type_size[8];
 
@@ -190,8 +191,8 @@ extern int fofs_visibility;
 extern int fofs_hide_players;
 extern int fofs_teleported;
 
-#define EdictFieldFloat(ed, fieldoffset) ((eval_t *)((byte *)&(ed)->v + (fieldoffset)))->_float
-#define EdictFieldVector(ed, fieldoffset) ((eval_t *)((byte *)&(ed)->v + (fieldoffset)))->vector
+#define EdictFieldFloat(ed, fieldoffset) ((eval_t *)((byte *)(ed)->v + (fieldoffset)))->_float
+#define EdictFieldVector(ed, fieldoffset) ((eval_t *)((byte *)(ed)->v + (fieldoffset)))->vector
 
 void PR_RunError (char *error, ...);
 

--- a/src/server.h
+++ b/src/server.h
@@ -95,10 +95,12 @@ typedef struct
 
 	int         num_edicts;         // increases towards MAX_EDICTS
 	int         num_baseline_edicts;// number of entities that have baselines
-	edict_t     *edicts;            // can NOT be array indexed, because
+
+	edict_t     edicts[MAX_EDICTS];
+    entvars_t   *game_edicts;            // can NOT be array indexed, because
 	                                // edict_t is variable sized, but can
 	                                // be used to reference the world ent
-	sv_edict_t  sv_edicts[MAX_EDICTS]; // part of the edict_t
+	//sv_edict_t  sv_edicts[MAX_EDICTS]; // part of the edict_t
 	int         max_edicts;         // might not MAX_EDICTS if mod allocates memory
 
 	byte		*pvs, *phs;			// fully expanded and decompressed

--- a/src/sv_ccmds.c
+++ b/src/sv_ccmds.c
@@ -279,8 +279,8 @@ void SV_God_f (void)
 	if (!SV_SetPlayer ())
 		return;
 
-	sv_player->v.flags = (int)sv_player->v.flags ^ FL_GODMODE;
-	if (!((int)sv_player->v.flags & FL_GODMODE) )
+	sv_player->v->flags = (int)sv_player->v->flags ^ FL_GODMODE;
+	if (!((int)sv_player->v->flags & FL_GODMODE) )
 		SV_ClientPrintf (sv_client, PRINT_HIGH, "godmode OFF\n");
 	else
 		SV_ClientPrintf (sv_client, PRINT_HIGH, "godmode ON\n");
@@ -298,14 +298,14 @@ void SV_Noclip_f (void)
 	if (!SV_SetPlayer ())
 		return;
 
-	if (sv_player->v.movetype != MOVETYPE_NOCLIP)
+	if (sv_player->v->movetype != MOVETYPE_NOCLIP)
 	{
-		sv_player->v.movetype = MOVETYPE_NOCLIP;
+		sv_player->v->movetype = MOVETYPE_NOCLIP;
 		SV_ClientPrintf (sv_client, PRINT_HIGH, "noclip ON\n");
 	}
 	else
 	{
-		sv_player->v.movetype = MOVETYPE_WALK;
+		sv_player->v->movetype = MOVETYPE_WALK;
 		SV_ClientPrintf (sv_client, PRINT_HIGH, "noclip OFF\n");
 	}
 }
@@ -346,23 +346,23 @@ void SV_Give_f (void)
 	case '7':
 	case '8':
 	case '9':
-		sv_player->v.items = (int)sv_player->v.items | IT_SHOTGUN<< (t[0] - '2');
+		sv_player->v->items = (int)sv_player->v->items | IT_SHOTGUN<< (t[0] - '2');
 		break;
 
 	case 's':
-		sv_player->v.ammo_shells = v;
+		sv_player->v->ammo_shells = v;
 		break;
 	case 'n':
-		sv_player->v.ammo_nails = v;
+		sv_player->v->ammo_nails = v;
 		break;
 	case 'r':
-		sv_player->v.ammo_rockets = v;
+		sv_player->v->ammo_rockets = v;
 		break;
 	case 'h':
-		sv_player->v.health = v;
+		sv_player->v->health = v;
 		break;
 	case 'c':
-		sv_player->v.ammo_cells = v;
+		sv_player->v->ammo_cells = v;
 		break;
 	}
 }
@@ -378,17 +378,17 @@ void SV_Fly_f (void)
 	if (!SV_SetPlayer ())
 		return;
 
-	if (sv_player->v.solid != SOLID_SLIDEBOX)
+	if (sv_player->v->solid != SOLID_SLIDEBOX)
 		return;		// dead don't fly
 
-	if (sv_player->v.movetype != MOVETYPE_FLY)
+	if (sv_player->v->movetype != MOVETYPE_FLY)
 	{
-		sv_player->v.movetype = MOVETYPE_FLY;
+		sv_player->v->movetype = MOVETYPE_FLY;
 		SV_ClientPrintf (sv_client, PRINT_HIGH, "flymode ON\n");
 	}
 	else
 	{
-		sv_player->v.movetype = MOVETYPE_WALK;
+		sv_player->v->movetype = MOVETYPE_WALK;
 		SV_ClientPrintf (sv_client, PRINT_HIGH, "flymode OFF\n");
 	}
 }
@@ -1203,7 +1203,7 @@ void SV_Status_f (void)
 					continue;
 				s = NET_BaseAdrToString(cl->netchan.remote_address);
 				Con_Printf ("%-16s %4i %5i %6i %-22s ", cl->name, (int)SV_CalcPing(cl),
-						(int)cl->edict->v.frags, cl->userid, (int)sv_use_dns.value ? SV_Resolve(s) : s);
+						(int)cl->edict->v->frags, cl->userid, (int)sv_use_dns.value ? SV_Resolve(s) : s);
 				if (cl->realip.ip[0])
 					Con_Printf ("%-15s", NET_BaseAdrToString (cl->realip));
 				Con_Printf (cl->spectator ? (char *) "(s)" : (char *) "");
@@ -1239,7 +1239,7 @@ void SV_Status_f (void)
 
 				s = NET_BaseAdrToString(cl->netchan.remote_address);
 				Con_Printf ("%-18s %4i %5i %6s %s\n%-36s\n", cl->name, (int)SV_CalcPing(cl),
-							(int)cl->edict->v.frags, Q_yelltext((unsigned char*)va("%d", cl->userid)),
+							(int)cl->edict->v->frags, Q_yelltext((unsigned char*)va("%d", cl->userid)),
 							cl->spectator ? " (s)" : "", (int)sv_use_dns.value ? SV_Resolve(s) : s);
 
 				if (cl->realip.ip[0])

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1207,7 +1207,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t *dest)
 	MSG_WriteFloat (&buf, sv.time);
 
 	// send full levelname
-	MSG_WriteString (&buf, PR_GetEntityString(sv.edicts->v.message));
+	MSG_WriteString (&buf, PR_GetEntityString(sv.edicts->v->message));
 
 	// send the movevars
 	MSG_WriteFloat(&buf, movevars.gravity);
@@ -1331,7 +1331,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t *dest)
 
 		for (i = 0; i < sv.num_baseline_edicts; ++i) {
 			edict_t* svent = EDICT_NUM(i);
-			entity_state_t* s = &svent->e->baseline;
+			entity_state_t* s = &svent->e.baseline;
 
 			if (buf.cursize >= MAX_MSGLEN/2) {
 				SV_WriteRecordMVDMessage (&buf);
@@ -1452,23 +1452,23 @@ void SV_MVD_SendInitialGamestate(mvddest_t *dest)
 		flags =   (DF_ORIGIN << 0) | (DF_ORIGIN << 1) | (DF_ORIGIN << 2)
 				| (DF_ANGLES << 0) | (DF_ANGLES << 1) | (DF_ANGLES << 2)
 				| DF_EFFECTS | DF_SKINNUM 
-				| (ent->v.health <= 0 ? DF_DEAD : 0)
-				| (ent->v.mins[2] != -24 ? DF_GIB : 0)
+				| (ent->v->health <= 0 ? DF_DEAD : 0)
+				| (ent->v->mins[2] != -24 ? DF_GIB : 0)
 				| DF_WEAPONFRAME | DF_MODEL;
 
-		VectorCopy(ent->v.origin, origin);
-		VectorCopy(ent->v.angles, angles);
+		VectorCopy(ent->v->origin, origin);
+		VectorCopy(ent->v->angles, angles);
 		angles[0] *= -3;
 #ifdef USE_PR2
 		if( player->isBot )
-			VectorCopy(ent->v.v_angle, angles);
+			VectorCopy(ent->v->v_angle, angles);
 #endif
 		angles[2] = 0; // no roll angle
 
-		if (ent->v.health <= 0)
+		if (ent->v->health <= 0)
 		{	// don't show the corpse looking around...
 			angles[0] = 0;
-			angles[1] = ent->v.angles[1];
+			angles[1] = ent->v->angles[1];
 			angles[2] = 0;
 		}
 
@@ -1476,7 +1476,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t *dest)
 		MSG_WriteByte (&buf, i);
 		MSG_WriteShort (&buf, flags);
 
-		MSG_WriteByte (&buf, ent->v.frame);
+		MSG_WriteByte (&buf, ent->v->frame);
 
 		for (j = 0 ; j < 3 ; j++)
 			if (flags & (DF_ORIGIN << j))
@@ -1487,16 +1487,16 @@ void SV_MVD_SendInitialGamestate(mvddest_t *dest)
 				MSG_WriteAngle16 (&buf, angles[j]);
 
 		if (flags & DF_MODEL)
-			MSG_WriteByte (&buf, ent->v.modelindex);
+			MSG_WriteByte (&buf, ent->v->modelindex);
 
 		if (flags & DF_SKINNUM)
-			MSG_WriteByte (&buf, ent->v.skin);
+			MSG_WriteByte (&buf, ent->v->skin);
 
 		if (flags & DF_EFFECTS)
-			MSG_WriteByte (&buf, ent->v.effects);
+			MSG_WriteByte (&buf, ent->v->effects);
 
 		if (flags & DF_WEAPONFRAME)
-			MSG_WriteByte (&buf, ent->v.weaponframe);
+			MSG_WriteByte (&buf, ent->v->weaponframe);
 
 		if (buf.cursize > MAX_MSGLEN/2)
 		{
@@ -1529,21 +1529,21 @@ void SV_MVD_SendInitialGamestate(mvddest_t *dest)
 
 		memset(stats, 0, sizeof(stats));
 
-		stats[STAT_HEALTH]       = ent->v.health;
-		stats[STAT_WEAPON]       = SV_ModelIndex(PR_GetEntityString(ent->v.weaponmodel));
-		stats[STAT_AMMO]         = ent->v.currentammo;
-		stats[STAT_ARMOR]        = ent->v.armorvalue;
-		stats[STAT_SHELLS]       = ent->v.ammo_shells;
-		stats[STAT_NAILS]        = ent->v.ammo_nails;
-		stats[STAT_ROCKETS]      = ent->v.ammo_rockets;
-		stats[STAT_CELLS]        = ent->v.ammo_cells;
-		stats[STAT_ACTIVEWEAPON] = ent->v.weapon;
+		stats[STAT_HEALTH]       = ent->v->health;
+		stats[STAT_WEAPON]       = SV_ModelIndex(PR_GetEntityString(ent->v->weaponmodel));
+		stats[STAT_AMMO]         = ent->v->currentammo;
+		stats[STAT_ARMOR]        = ent->v->armorvalue;
+		stats[STAT_SHELLS]       = ent->v->ammo_shells;
+		stats[STAT_NAILS]        = ent->v->ammo_nails;
+		stats[STAT_ROCKETS]      = ent->v->ammo_rockets;
+		stats[STAT_CELLS]        = ent->v->ammo_cells;
+		stats[STAT_ACTIVEWEAPON] = ent->v->weapon;
 
-		if (ent->v.health > 0) // viewheight for PF_DEAD & PF_GIB is hardwired
-			stats[STAT_VIEWHEIGHT] = ent->v.view_ofs[2];
+		if (ent->v->health > 0) // viewheight for PF_DEAD & PF_GIB is hardwired
+			stats[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
 
 		// stuff the sigil bits into the high bits of items for sbar
-		stats[STAT_ITEMS] = (int) ent->v.items | ((int) PR_GLOBAL(serverflags) << 28);
+		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 
 		for (j = 0; j < MAX_CL_STATS; j++)
 		{

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -43,7 +43,7 @@ static qbool SV_AddNailUpdate (edict_t *ent)
 	if ((int)sv_nailhack.value)
 		return false;
 
-	if (ent->v.modelindex != sv_nailmodel && ent->v.modelindex != sv_supernailmodel)
+	if (ent->v->modelindex != sv_nailmodel && ent->v->modelindex != sv_supernailmodel)
 		return false;
 
 	if (msg_coordsize != 2)
@@ -79,20 +79,20 @@ static void SV_EmitNailUpdate (sizebuf_t *msg, qbool recorder)
 		ent = nails[n];
 		if (recorder)
 		{
-			if (!ent->v.colormap)
+			if (!ent->v->colormap)
 			{
 				if (!((++nailcount)&255)) nailcount++;
-				ent->v.colormap = nailcount&255;
+				ent->v->colormap = nailcount&255;
 			}
 
-			MSG_WriteByte (msg, (byte)ent->v.colormap);
+			MSG_WriteByte (msg, (byte)ent->v->colormap);
 		}
 
-		x = ((int)(ent->v.origin[0] + 4096 + 1) >> 1) & 4095;
-		y = ((int)(ent->v.origin[1] + 4096 + 1) >> 1) & 4095;
-		z = ((int)(ent->v.origin[2] + 4096 + 1) >> 1) & 4095;
-		p = Q_rint(ent->v.angles[0]*(16.0/360.0)) & 15;
-		yaw = Q_rint(ent->v.angles[1]*(256.0/360.0)) & 255;
+		x = ((int)(ent->v->origin[0] + 4096 + 1) >> 1) & 4095;
+		y = ((int)(ent->v->origin[1] + 4096 + 1) >> 1) & 4095;
+		z = ((int)(ent->v->origin[2] + 4096 + 1) >> 1) & 4095;
+		p = Q_rint(ent->v->angles[0]*(16.0/360.0)) & 15;
+		yaw = Q_rint(ent->v->angles[1]*(256.0/360.0)) & 255;
 
 		bits[0] = x;
 		bits[1] = (x>>8) | (y<<4);
@@ -349,7 +349,7 @@ static void SV_EmitPacketEntities (client_t *client, packet_entities_t *to, size
 			}
 			ent = EDICT_NUM(newnum);
 			//Con_Printf ("baseline %i\n", newnum);
-			SV_WriteDelta (client, &ent->e->baseline, &to->entities[newindex], msg, true);
+			SV_WriteDelta (client, &ent->e.baseline, &to->entities[newindex], msg, true);
 			newindex++;
 			continue;
 		}
@@ -387,13 +387,13 @@ static void SV_EmitPacketEntities (client_t *client, packet_entities_t *to, size
 
 static int TranslateEffects (edict_t *ent)
 {
-	int fx = (int)ent->v.effects;
+	int fx = (int)ent->v->effects;
 	if (pr_nqprogs)
 		fx &= ~EF_MUZZLEFLASH;
 	if (pr_nqprogs && (fx & EF_DIMLIGHT)) {
-		if ((int)ent->v.items & IT_QUAD)
+		if ((int)ent->v->items & IT_QUAD)
 			fx |= EF_BLUE;
-		if ((int)ent->v.items & IT_INVULNERABILITY)
+		if ((int)ent->v->items & IT_INVULNERABILITY)
 			fx |= EF_RED;
 	}
 	return fx;
@@ -426,26 +426,26 @@ static void SV_MVD_WritePlayersToClient ( void )
 
 		dcl->parsecount = demo.parsecount;
 
-		VectorCopy(ent->v.origin, dcl->origin);
-		VectorCopy(ent->v.angles, dcl->angles);
+		VectorCopy(ent->v->origin, dcl->origin);
+		VectorCopy(ent->v->angles, dcl->angles);
 		dcl->angles[0] *= -3;
 #ifdef USE_PR2
 		if( cl->isBot )
-			VectorCopy(ent->v.v_angle, dcl->angles);
+			VectorCopy(ent->v->v_angle, dcl->angles);
 #endif
 		dcl->angles[2] = 0; // no roll angle
 
-		if (ent->v.health <= 0)
+		if (ent->v->health <= 0)
 		{	// don't show the corpse looking around...
 			dcl->angles[0] = 0;
-			dcl->angles[1] = ent->v.angles[1];
+			dcl->angles[1] = ent->v->angles[1];
 			dcl->angles[2] = 0;
 		}
 
-		dcl->weaponframe = ent->v.weaponframe;
-		dcl->frame       = ent->v.frame;
-		dcl->skinnum     = ent->v.skin;
-		dcl->model       = ent->v.modelindex;
+		dcl->weaponframe = ent->v->weaponframe;
+		dcl->frame       = ent->v->frame;
+		dcl->skinnum     = ent->v->skin;
+		dcl->model       = ent->v->modelindex;
 		dcl->effects     = TranslateEffects(ent);
 		dcl->flags       = 0;
 
@@ -454,9 +454,9 @@ static void SV_MVD_WritePlayersToClient ( void )
 
 		dcl->sec         = sv.time - cl->localtime;
 
-		if (ent->v.health <= 0)
+		if (ent->v->health <= 0)
 			dcl->flags |= DF_DEAD;
-		if (ent->v.mins[2] != -24)
+		if (ent->v->mins[2] != -24)
 			dcl->flags |= DF_GIB;
 
 		continue;
@@ -480,14 +480,14 @@ qbool SV_PlayerVisibleToClient (client_t* client, int j, byte* pvs, edict_t* sel
 		if (cl->spectator)
 			return false;
 
-		if (pvs && ent->e->num_leafs >= 0) {
+		if (pvs && ent->e.num_leafs >= 0) {
 			// ignore if not touching a PV leaf
-			for (i = 0; i < ent->e->num_leafs; i++) {
-				if (pvs[ent->e->leafnums[i] >> 3] & (1 << (ent->e->leafnums[i] & 7))) {
+			for (i = 0; i < ent->e.num_leafs; i++) {
+				if (pvs[ent->e.leafnums[i] >> 3] & (1 << (ent->e.leafnums[i] & 7))) {
 					break;
 				}
 			}
-			if (i == ent->e->num_leafs) {
+			if (i == ent->e.num_leafs) {
 				return false; // not visible
 			}
 		}
@@ -509,14 +509,14 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 	usercmd_t cmd;
 	int hideent = 0;
 	int trackent = 0;
-	qbool hide_players = fofs_hide_players && ((eval_t *)((byte *)&(client->edict)->v + fofs_hide_players))->_int;
+	qbool hide_players = fofs_hide_players && ((eval_t *)((byte *)(client->edict)->v + fofs_hide_players))->_int;
 
 	if (fofs_hideentity)
-		hideent = ((eval_t *)((byte *)&(client->edict)->v + fofs_hideentity))->_int / pr_edict_size;
+		hideent = ((eval_t *)((byte *)(client->edict)->v + fofs_hideentity))->_int / pr_edict_size;
 
 	if (fofs_trackent)
 	{
-		trackent = ((eval_t *)((byte *)&(client->edict)->v + fofs_trackent))->_int;
+		trackent = ((eval_t *)((byte *)(client->edict)->v + fofs_trackent))->_int;
 		if (trackent < 1 || trackent > MAX_CLIENTS || svs.clients[trackent - 1].state != cs_spawned)
 			trackent = 0;
 	}
@@ -532,7 +532,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 
 		if (fofs_visibility) {
 			// Presume not visible
-			((eval_t *)((byte *)&(cl->edict)->v + fofs_visibility))->_int &= ~(1 << (client - svs.clients));
+			((eval_t *)((byte *)(cl->edict)->v + fofs_visibility))->_int &= ~(1 << (client - svs.clients));
 		}
 
 		if (cl->state != cs_spawned)
@@ -562,7 +562,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 
 		if (fofs_visibility) {
 			// Update flags so mods can tell what was visible
-			((eval_t *)((byte *)&(ent)->v + fofs_visibility))->_int |= (1 << (client - svs.clients));
+			((eval_t *)((byte *)(ent)->v + fofs_visibility))->_int |= (1 << (client - svs.clients));
 		}
 
 		if (j == hideent - 1)
@@ -581,18 +581,18 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 
 		pflags = PF_MSEC | PF_COMMAND;
 
-		if (ent->v.modelindex != sv_playermodel)
+		if (ent->v->modelindex != sv_playermodel)
 			pflags |= PF_MODEL;
 		for (i=0 ; i<3 ; i++)
-			if (ent->v.velocity[i])
+			if (ent->v->velocity[i])
 				pflags |= PF_VELOCITY1<<i;
-		if (ent->v.effects)
+		if (ent->v->effects)
 			pflags |= PF_EFFECTS;
-		if (ent->v.skin || ent->v.modelindex >= 256)
+		if (ent->v->skin || ent->v->modelindex >= 256)
 			pflags |= PF_SKINNUM;
-		if (ent->v.health <= 0)
+		if (ent->v->health <= 0)
 			pflags |= PF_DEAD;
-		if (ent->v.mins[2] != -24)
+		if (ent->v->mins[2] != -24)
 			pflags |= PF_GIB;
 
 		if (cl->spectator)
@@ -602,7 +602,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		else if (ent == self_ent)
 		{	// don't send a lot of data on personal entity
 			pflags &= ~(PF_MSEC|PF_COMMAND);
-			if (ent->v.weaponframe)
+			if (ent->v->weaponframe)
 				pflags |= PF_WEAPONFRAME;
 		}
 
@@ -641,17 +641,17 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		pflags |= pm_code << PF_PMC_SHIFT;
 
 		// Z_EXT_PF_ONGROUND protocol extension
-		if ((int)ent->v.flags & FL_ONGROUND)
+		if ((int)ent->v->flags & FL_ONGROUND)
 			pflags |= PF_ONGROUND;
 
 		// Z_EXT_PF_SOLID protocol extension
-		if (ent->v.solid == SOLID_BBOX || ent->v.solid == SOLID_SLIDEBOX)
+		if (ent->v->solid == SOLID_BBOX || ent->v->solid == SOLID_SLIDEBOX)
 			pflags |= PF_SOLID;
 
 		if (pm_type == PM_LOCK && ent == self_ent)
 			pflags |= PF_COMMAND;	// send forced view angles
 
-		if (client->spec_track && client->spec_track - 1 == j && ent->v.weaponframe)
+		if (client->spec_track && client->spec_track - 1 == j && ent->v->weaponframe)
 			pflags |= PF_WEAPONFRAME;
 
 		MSG_WriteByte (msg, svc_playerinfo);
@@ -659,17 +659,17 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		MSG_WriteShort (msg, pflags);
 
 		if (client->mvdprotocolextensions1 & MVD_PEXT1_FLOATCOORDS) {
-			MSG_WriteLongCoord(msg, ent->v.origin[0]);
-			MSG_WriteLongCoord(msg, ent->v.origin[1]);
-			MSG_WriteLongCoord(msg, ent->v.origin[2]);
+			MSG_WriteLongCoord(msg, ent->v->origin[0]);
+			MSG_WriteLongCoord(msg, ent->v->origin[1]);
+			MSG_WriteLongCoord(msg, ent->v->origin[2]);
 		}
 		else {
-			MSG_WriteCoord(msg, ent->v.origin[0]);
-			MSG_WriteCoord(msg, ent->v.origin[1]);
-			MSG_WriteCoord(msg, ent->v.origin[2]);
+			MSG_WriteCoord(msg, ent->v->origin[0]);
+			MSG_WriteCoord(msg, ent->v->origin[1]);
+			MSG_WriteCoord(msg, ent->v->origin[2]);
 		}
 
-		MSG_WriteByte (msg, ent->v.frame);
+		MSG_WriteByte (msg, ent->v->frame);
 
 		if (pflags & PF_MSEC)
 		{
@@ -683,10 +683,10 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		{
 			cmd = cl->lastcmd;
 
-			if (ent->v.health <= 0)
+			if (ent->v->health <= 0)
 			{	// don't show the corpse looking around...
 				cmd.angles[0] = 0;
-				cmd.angles[1] = ent->v.angles[1];
+				cmd.angles[1] = ent->v->angles[1];
 				cmd.angles[0] = 0;
 			}
 
@@ -696,7 +696,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 			if (ent == self_ent)
 			{
 				// this is PM_LOCK, we only want to send view angles
-				VectorCopy(ent->v.v_angle, cmd.angles);
+				VectorCopy(ent->v->v_angle, cmd.angles);
 				cmd.forwardmove = 0;
 				cmd.sidemove = 0;
 				cmd.upmove = 0;
@@ -711,19 +711,19 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 
 		for (i=0 ; i<3 ; i++)
 			if (pflags & (PF_VELOCITY1<<i) )
-				MSG_WriteShort (msg, ent->v.velocity[i]);
+				MSG_WriteShort (msg, ent->v->velocity[i]);
 
 		if (pflags & PF_MODEL)
-			MSG_WriteByte (msg, ent->v.modelindex);
+			MSG_WriteByte (msg, ent->v->modelindex);
 
 		if (pflags & PF_SKINNUM)
-			MSG_WriteByte (msg, (int)ent->v.skin | (((pflags & PF_MODEL)&&(ent->v.modelindex >= 256))<<7));
+			MSG_WriteByte (msg, (int)ent->v->skin | (((pflags & PF_MODEL)&&(ent->v->modelindex >= 256))<<7));
 
 		if (pflags & PF_EFFECTS)
 			MSG_WriteByte (msg, TranslateEffects(ent));
 
 		if (pflags & PF_WEAPONFRAME)
-			MSG_WriteByte (msg, ent->v.weaponframe);
+			MSG_WriteByte (msg, ent->v->weaponframe);
 	}
 }
 
@@ -744,19 +744,19 @@ qbool SV_EntityVisibleToClient (client_t* client, int e, byte* pvs)
 	}
 
 	// ignore ents without visible models
-	if (!ent->v.modelindex || !*PR_GetEntityString(ent->v.model))
+	if (!ent->v->modelindex || !*PR_GetEntityString(ent->v->model))
 		return false;
 
-	if ( pvs && ent->e->num_leafs >= 0 )
+	if ( pvs && ent->e.num_leafs >= 0 )
 	{
 		int i;
 
 		// ignore if not touching a PV leaf
-		for (i=0 ; i < ent->e->num_leafs ; i++)
-			if (pvs[ent->e->leafnums[i] >> 3] & (1 << (ent->e->leafnums[i]&7) ))
+		for (i=0 ; i < ent->e.num_leafs ; i++)
+			if (pvs[ent->e.leafnums[i] >> 3] & (1 << (ent->e.leafnums[i]&7) ))
 				break;
 
-		if (i == ent->e->num_leafs)
+		if (i == ent->e.num_leafs)
 			return false;		// not visible
 	}
 
@@ -815,13 +815,13 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 		int trackent = 0;
 
 		if (fofs_hideentity)
-			hideent = ((eval_t *)((byte *)&(client->edict)->v + fofs_hideentity))->_int / pr_edict_size;
+			hideent = ((eval_t *)((byte *)(client->edict)->v + fofs_hideentity))->_int / pr_edict_size;
 		else
 			hideent = 0;
 
 		if (fofs_trackent)
 		{
-			trackent = ((eval_t *)((byte *)&(client->edict)->v + fofs_trackent))->_int;
+			trackent = ((eval_t *)((byte *)(client->edict)->v + fofs_trackent))->_int;
 			if (trackent < 1 || trackent > MAX_CLIENTS || svs.clients[trackent - 1].state != cs_spawned)
 				trackent = 0;
 		}
@@ -829,11 +829,11 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 		// we should use org of tracked player in case or trackent.
 		if (trackent)
 		{
-			VectorAdd (svs.clients[trackent - 1].edict->v.origin, svs.clients[trackent - 1].edict->v.view_ofs, org);		
+			VectorAdd (svs.clients[trackent - 1].edict->v->origin, svs.clients[trackent - 1].edict->v->view_ofs, org);		
 		}
 		else
 		{
-			VectorAdd (client->edict->v.origin, client->edict->v.view_ofs, org);
+			VectorAdd (client->edict->v->origin, client->edict->v->view_ofs, org);
 		}
 
 		pvs = CM_FatPVS (org); // search some PVS
@@ -844,7 +844,7 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 			#define ISUNDERWATER(x) ((x) == CONTENTS_WATER || (x) == CONTENTS_SLIME || (x) == CONTENTS_LAVA)
 
 			// server flash should not work underwater
-			int content = CM_HullPointContents(&sv.worldmodel->hulls[0], 0, client->edict->v.origin);
+			int content = CM_HullPointContents(&sv.worldmodel->hulls[0], 0, client->edict->v->origin);
 			disable_updates = !ISUNDERWATER(content);
 
 			#undef ISUNDERWATER
@@ -878,14 +878,14 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 		{
 			if (!SV_EntityVisibleToClient(client, e, pvs)) {
 				if (fofs_visibility) {
-					((eval_t *)((byte *)&(ent)->v + fofs_visibility))->_int &= ~client_flag;
+					((eval_t *)((byte *)(ent)->v + fofs_visibility))->_int &= ~client_flag;
 				}
 				continue;
 			}
 
 			if (fofs_visibility) {
 				// Don't include other filters in logic for setting this field
-				((eval_t *)((byte *)&(ent)->v + fofs_visibility))->_int |= (1 << (client - svs.clients));
+				((eval_t *)((byte *)(ent)->v + fofs_visibility))->_int |= (1 << (client - svs.clients));
 			}
 
 			if (e == hideent) {
@@ -896,8 +896,8 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 				continue; // added to the special update list
 
 			if (clent) {
-				VectorAdd(ent->v.absmin, ent->v.absmax, org);
-				VectorMA(clent->v.origin, -0.5, org, org);
+				VectorAdd(ent->v->absmin, ent->v->absmax, org);
+				VectorMA(clent->v->origin, -0.5, org, org);
 				distance = DotProduct(org, org);	//Length
 
 				// add to the packetentities
@@ -942,12 +942,12 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 
 			state->number = e;
 			state->flags = 0;
-			VectorCopy (ent->v.origin, state->origin);
-			VectorCopy (ent->v.angles, state->angles);
-			state->modelindex = ent->v.modelindex;
-			state->frame = ent->v.frame;
-			state->colormap = ent->v.colormap;
-			state->skinnum = ent->v.skin;
+			VectorCopy (ent->v->origin, state->origin);
+			VectorCopy (ent->v->angles, state->angles);
+			state->modelindex = ent->v->modelindex;
+			state->frame = ent->v->frame;
+			state->colormap = ent->v->colormap;
+			state->skinnum = ent->v->skin;
 			state->effects = TranslateEffects(ent);
 		}
 	} // server flash
@@ -966,18 +966,18 @@ void SV_WriteEntitiesToClient (client_t *client, sizebuf_t *msg, qbool recorder)
 		for (e=1, ent=EDICT_NUM(e) ; e < sv.num_edicts ; e++, ent = NEXT_EDICT(ent))
 		{
 			// ignore ents without visible models
-			if (!ent->v.modelindex || !*PR_GetEntityString(ent->v.model))
+			if (!ent->v->modelindex || !*PR_GetEntityString(ent->v->model))
 				continue;
 
 			// ignore if not touching a PV leaf (meag: this does nothing... complete or remove?)
-			if (pvs && ent->e->num_leafs >= 0) {
-				for (i = 0; i < ent->e->num_leafs; i++)
-					if (pvs[ent->e->leafnums[i] >> 3] & (1 << (ent->e->leafnums[i] & 7)))
+			if (pvs && ent->e.num_leafs >= 0) {
+				for (i = 0; i < ent->e.num_leafs; i++)
+					if (pvs[ent->e.leafnums[i] >> 3] & (1 << (ent->e.leafnums[i] & 7)))
 						break;
 			}
 
-			if ((int)ent->v.effects & EF_MUZZLEFLASH) {
-				ent->v.effects = (int)ent->v.effects & ~EF_MUZZLEFLASH;
+			if ((int)ent->v->effects & EF_MUZZLEFLASH) {
+				ent->v->effects = (int)ent->v->effects & ~EF_MUZZLEFLASH;
 				MSG_WriteByte (msg, svc_muzzleflash);
 				MSG_WriteShort (msg, e);
 			}
@@ -1001,17 +1001,17 @@ void SV_SetVisibleEntitiesForBot (client_t* client)
 	if (!fofs_visibility)
 		return;
 
-	VectorAdd (client->edict->v.origin, client->edict->v.view_ofs, org);
+	VectorAdd (client->edict->v->origin, client->edict->v->view_ofs, org);
 	pvs = CM_FatPVS (org); // search some PVS
 
 	// players first
 	for (j = 0; j < MAX_CLIENTS; j++)
 	{
 		if (SV_PlayerVisibleToClient(client, j, pvs, client->edict, svs.clients[j].edict)) {
-			((eval_t *)((byte *)&(svs.clients[j].edict)->v + fofs_visibility))->_int |= client_flag;
+			((eval_t *)((byte *)(svs.clients[j].edict)->v + fofs_visibility))->_int |= client_flag;
 		}
 		else {
-			((eval_t *)((byte *)&(svs.clients[j].edict)->v + fofs_visibility))->_int &= ~client_flag;
+			((eval_t *)((byte *)(svs.clients[j].edict)->v + fofs_visibility))->_int &= ~client_flag;
 		}
 	}
 
@@ -1021,10 +1021,10 @@ void SV_SetVisibleEntitiesForBot (client_t* client)
 		edict_t* ent = EDICT_NUM (e);
 
 		if (SV_EntityVisibleToClient(client, e, pvs)) {
-			((eval_t *)((byte *)&(ent)->v + fofs_visibility))->_int |= client_flag;
+			((eval_t *)((byte *)(ent)->v + fofs_visibility))->_int |= client_flag;
 		}
 		else {
-			((eval_t *)((byte *)&(ent)->v + fofs_visibility))->_int &= ~client_flag;
+			((eval_t *)((byte *)(ent)->v + fofs_visibility))->_int &= ~client_flag;
 		}
 	}
 }

--- a/src/sv_init.c
+++ b/src/sv_init.c
@@ -99,30 +99,30 @@ static void SV_CreateBaseline (void)
 	for (entnum = 0; entnum < sv.num_edicts ; entnum++)
 	{
 		svent = EDICT_NUM(entnum);
-		if (svent->e->free)
+		if (svent->e.free)
 			continue;
 		// create baselines for all player slots,
 		// and any other edict that has a visible model
-		if (entnum > MAX_CLIENTS && !svent->v.modelindex)
+		if (entnum > MAX_CLIENTS && !svent->v->modelindex)
 			continue;
 
 		//
 		// create entity baseline
 		//
-		svent->e->baseline.number = entnum;
-		VectorCopy (svent->v.origin, svent->e->baseline.origin);
-		VectorCopy (svent->v.angles, svent->e->baseline.angles);
-		svent->e->baseline.frame = svent->v.frame;
-		svent->e->baseline.skinnum = svent->v.skin;
+		svent->e.baseline.number = entnum;
+		VectorCopy (svent->v->origin, svent->e.baseline.origin);
+		VectorCopy (svent->v->angles, svent->e.baseline.angles);
+		svent->e.baseline.frame = svent->v->frame;
+		svent->e.baseline.skinnum = svent->v->skin;
 		if (entnum > 0 && entnum <= MAX_CLIENTS)
 		{
-			svent->e->baseline.colormap = entnum;
-			svent->e->baseline.modelindex = SV_ModelIndex("progs/player.mdl");
+			svent->e.baseline.colormap = entnum;
+			svent->e.baseline.modelindex = SV_ModelIndex("progs/player.mdl");
 		}
 		else
 		{
-			svent->e->baseline.colormap = 0;
-			svent->e->baseline.modelindex = svent->v.modelindex;
+			svent->e.baseline.colormap = 0;
+			svent->e.baseline.modelindex = svent->v->modelindex;
 		}
 	}
 	sv.num_baseline_edicts = sv.num_edicts;
@@ -238,7 +238,7 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 		if( sv_vm && svs.clients[i].isBot )
 		{
 			svs.clients[i].old_frags = 0;
-			svs.clients[i].edict->v.frags = 0.0;
+			svs.clients[i].edict->v->frags = 0.0;
 			svs.clients[i].name[0] = 0;
 			svs.clients[i].state = cs_free;
 			Info_RemoveAll(&svs.clients[i]._userinfo_ctx_);
@@ -347,11 +347,13 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 
 	for (i = 0; i < sv.max_edicts; i++)
 	{
+        sv.edicts[i].v = (entvars_t *)((byte *)sv.game_edicts+ (i)*pr_edict_size);
 		ent = EDICT_NUM(i);
-		ent->e = &sv.sv_edicts[i]; // assigning ->e field in each edict_t
-		ent->e->entnum = i;
-		ent->e->area.ed = ent; // yeah, pretty funny, but this help to find which edict_t own this area (link_t)
-		PR_ClearEdict(ent);
+		//ent->e = &sv.sv_edicts[i]; // assigning ->e field in each edict_t
+		//sv.edicts[i].e = &sv.sv_edicts[i];
+		sv.edicts[i].e.entnum = i;
+		sv.edicts[i].e.area.ed = ent; // yeah, pretty funny, but this help to find which edict_t own this area (link_t)
+		PR_ClearEdict(&sv.edicts[i]);
 	}
 
 	fofs_items2 = ED_FindFieldOffset ("items2"); // ZQ_ITEMS2 extension
@@ -394,7 +396,7 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 	{
 		ent = EDICT_NUM(i+1);
 		// restore client name.
-		PR_SetEntityString(ent, ent->v.netname, svs.clients[i].name);
+		PR_SetEntityString(ent, ent->v->netname, svs.clients[i].name);
 		// reserve edict.
 		svs.clients[i].edict = ent;
 		//ZOID - make sure we update frags right
@@ -476,17 +478,17 @@ void SV_SpawnServer(char *mapname, qbool devmap, char* entityfile, qbool loading
 #endif
 
 	ent = EDICT_NUM(0);
-	ent->e->free = false;
-	PR_SetEntityString(ent, ent->v.model, sv.modelname);
-	ent->v.modelindex = 1;		// world model
-	ent->v.solid = SOLID_BSP;
-	ent->v.movetype = MOVETYPE_PUSH;
+	ent->e.free = false;
+	PR_SetEntityString(ent, ent->v->model, sv.modelname);
+	ent->v->modelindex = 1;		// world model
+	ent->v->solid = SOLID_BSP;
+	ent->v->movetype = MOVETYPE_PUSH;
 
 	// information about the server
-	PR_SetEntityString(ent, ent->v.netname, VersionStringFull());
-	PR_SetEntityString(ent, ent->v.targetname, SERVER_NAME);
-	ent->v.impulse = VERSION_NUM;
-	ent->v.items = pr_numbuiltins - 1;
+	PR_SetEntityString(ent, ent->v->netname, VersionStringFull());
+	PR_SetEntityString(ent, ent->v->targetname, SERVER_NAME);
+	ent->v->impulse = VERSION_NUM;
+	ent->v->items = pr_numbuiltins - 1;
 
 	PR_SetGlobalString(PR_GLOBAL(mapname), sv.mapname);
 	// serverflags are for cross level information (sigils)

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -403,7 +403,7 @@ void SV_DropClient (client_t *drop)
 // <-- MD
 
 	drop->old_frags = 0;
-	drop->edict->v.frags = 0.0;
+	drop->edict->v->frags = 0.0;
 	drop->name[0] = 0;
 
 	Info_RemoveAll(&drop->_userinfo_ctx_);
@@ -1356,10 +1356,10 @@ static void SVC_DirectConnect (void)
 
 	edictnum = (newcl-svs.clients)+1;
 	ent = EDICT_NUM(edictnum);
-	ent->e->free = false;
+	ent->e.free = false;
 	newcl->edict = ent;
 	// restore client name.
-	PR_SetEntityString(ent, ent->v.netname, newcl->name);
+	PR_SetEntityString(ent, ent->v->netname, newcl->name);
 
 	s = ( vip ? va("%d", vip) : "" );
 
@@ -1511,14 +1511,14 @@ int Rcon_Validate (char *client_string, char *password1)
 			}
 		}
 		SHA1_Init();
-		SHA1_Update((unsigned char*)Cmd_Argv(0));
-		SHA1_Update((unsigned char*)" ");
-		SHA1_Update((unsigned char*)password1);
-		SHA1_Update((unsigned char*)Cmd_Argv(1) + DIGEST_SIZE * 2);
-		SHA1_Update((unsigned char*)" ");
+		SHA1_Update((char*)Cmd_Argv(0));
+		SHA1_Update((char*)" ");
+		SHA1_Update((char*)password1);
+		SHA1_Update((char*)Cmd_Argv(1) + DIGEST_SIZE * 2);
+		SHA1_Update((char*)" ");
 		for (i = 2; (int) i < Cmd_Argc(); i++) {
-			SHA1_Update((unsigned char*)Cmd_Argv(i));
-			SHA1_Update((unsigned char*)" ");
+			SHA1_Update((char*)Cmd_Argv(i));
+			SHA1_Update((char*)" ");
 		}
 		if (strncmp(Cmd_Argv(1), SHA1_Final(), DIGEST_SIZE * 2)) {
 			return 0;

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3286,7 +3286,7 @@ void SV_InitLocal (void)
 
 	extern	cvar_t	pm_airstep;
 	extern	cvar_t	pm_pground;
-	//extern	cvar_t	pm_slidefix;
+	extern	cvar_t	pm_slidefix;
 	extern	cvar_t	pm_ktjump;
 	//extern	cvar_t	pm_bunnyspeedcap;
 	packet_t *packet_freeblock; // initialise delayed packet free block
@@ -3377,7 +3377,7 @@ void SV_InitLocal (void)
 
 	//Cvar_Register (&pm_bunnyspeedcap);
 	Cvar_Register (&pm_ktjump);
-	//Cvar_Register (&pm_slidefix);
+	Cvar_Register (&pm_slidefix);
 	Cvar_Register (&pm_pground);
 	Cvar_Register (&pm_airstep);
 

--- a/src/sv_move.c
+++ b/src/sv_move.c
@@ -40,8 +40,8 @@ qbool SV_CheckBottom (edict_t *ent)
 	int		x, y;
 	float	mid, bottom;
 
-	VectorAdd (ent->v.origin, ent->v.mins, mins);
-	VectorAdd (ent->v.origin, ent->v.maxs, maxs);
+	VectorAdd (ent->v->origin, ent->v->mins, mins);
+	VectorAdd (ent->v->origin, ent->v->maxs, maxs);
 
 	// if all of the points under the corners are solid world, don't bother
 	// with the tougher checks
@@ -110,33 +110,33 @@ qbool SV_movestep (edict_t *ent, vec3_t move, qbool relink)
 	edict_t		*enemy;
 
 	// try the move
-	VectorCopy (ent->v.origin, oldorg);
-	VectorAdd (ent->v.origin, move, neworg);
+	VectorCopy (ent->v->origin, oldorg);
+	VectorAdd (ent->v->origin, move, neworg);
 
 	// flying monsters don't step up
-	if ( (int)ent->v.flags & (FL_SWIM | FL_FLY) )
+	if ( (int)ent->v->flags & (FL_SWIM | FL_FLY) )
 	{
 		// try one move with vertical motion, then one without
 		for (i=0 ; i<2 ; i++)
 		{
-			VectorAdd (ent->v.origin, move, neworg);
-			enemy = PROG_TO_EDICT(ent->v.enemy);
+			VectorAdd (ent->v->origin, move, neworg);
+			enemy = PROG_TO_EDICT(ent->v->enemy);
 			if (i == 0 && enemy != sv.edicts)
 			{
-				dz = ent->v.origin[2] - PROG_TO_EDICT(ent->v.enemy)->v.origin[2];
+				dz = ent->v->origin[2] - PROG_TO_EDICT(ent->v->enemy)->v->origin[2];
 				if (dz > 40)
 					neworg[2] -= 8;
 				if (dz < 30)
 					neworg[2] += 8;
 			}
-			trace = SV_Trace (ent->v.origin, ent->v.mins, ent->v.maxs, neworg, false, ent);
+			trace = SV_Trace (ent->v->origin, ent->v->mins, ent->v->maxs, neworg, false, ent);
 
 			if (trace.fraction == 1)
 			{
-				if ( ((int)ent->v.flags & FL_SWIM) && SV_PointContents(trace.endpos) == CONTENTS_EMPTY )
+				if ( ((int)ent->v->flags & FL_SWIM) && SV_PointContents(trace.endpos) == CONTENTS_EMPTY )
 					return false;	// swim monster left water
 
-				VectorCopy (trace.endpos, ent->v.origin);
+				VectorCopy (trace.endpos, ent->v->origin);
 				if (relink)
 					SV_LinkEdict (ent, true);
 				return true;
@@ -154,7 +154,7 @@ qbool SV_movestep (edict_t *ent, vec3_t move, qbool relink)
 	VectorCopy (neworg, end);
 	end[2] -= STEPSIZE*2;
 
-	trace = SV_Trace (neworg, ent->v.mins, ent->v.maxs, end, false, ent);
+	trace = SV_Trace (neworg, ent->v->mins, ent->v->maxs, end, false, ent);
 
 	if (trace.allsolid)
 		return false;
@@ -162,19 +162,19 @@ qbool SV_movestep (edict_t *ent, vec3_t move, qbool relink)
 	if (trace.startsolid)
 	{
 		neworg[2] -= STEPSIZE;
-		trace = SV_Trace (neworg, ent->v.mins, ent->v.maxs, end, false, ent);
+		trace = SV_Trace (neworg, ent->v->mins, ent->v->maxs, end, false, ent);
 		if (trace.allsolid || trace.startsolid)
 			return false;
 	}
 	if (trace.fraction == 1)
 	{
 		// if monster had the ground pulled out, go ahead and fall
-		if ( (int)ent->v.flags & FL_PARTIALGROUND )
+		if ( (int)ent->v->flags & FL_PARTIALGROUND )
 		{
-			VectorAdd (ent->v.origin, move, ent->v.origin);
+			VectorAdd (ent->v->origin, move, ent->v->origin);
 			if (relink)
 				SV_LinkEdict (ent, true);
-			ent->v.flags = (int)ent->v.flags & ~FL_ONGROUND;
+			ent->v->flags = (int)ent->v->flags & ~FL_ONGROUND;
 			//	Con_Printf ("fall down\n");
 			return true;
 		}
@@ -183,27 +183,27 @@ qbool SV_movestep (edict_t *ent, vec3_t move, qbool relink)
 	}
 
 	// check point traces down for dangling corners
-	VectorCopy (trace.endpos, ent->v.origin);
+	VectorCopy (trace.endpos, ent->v->origin);
 
 	if (!SV_CheckBottom (ent))
 	{
-		if ( (int)ent->v.flags & FL_PARTIALGROUND )
+		if ( (int)ent->v->flags & FL_PARTIALGROUND )
 		{	// entity had floor mostly pulled out from underneath it
 			// and is trying to correct
 			if (relink)
 				SV_LinkEdict (ent, true);
 			return true;
 		}
-		VectorCopy (oldorg, ent->v.origin);
+		VectorCopy (oldorg, ent->v->origin);
 		return false;
 	}
 
-	if ( (int)ent->v.flags & FL_PARTIALGROUND )
+	if ( (int)ent->v->flags & FL_PARTIALGROUND )
 	{
 		//		Con_Printf ("back on ground\n");
-		ent->v.flags = (int)ent->v.flags & ~FL_PARTIALGROUND;
+		ent->v->flags = (int)ent->v->flags & ~FL_PARTIALGROUND;
 	}
-	ent->v.groundentity = EDICT_TO_PROG(trace.e.ent);
+	ent->v->groundentity = EDICT_TO_PROG(trace.e.ent);
 
 	// the move is ok
 	if (relink)
@@ -229,7 +229,7 @@ qbool SV_StepDirection (edict_t *ent, float yaw, float dist)
 	vec3_t		move, oldorigin;
 	float		delta;
 
-	ent->v.ideal_yaw = yaw;
+	ent->v->ideal_yaw = yaw;
 
 	PF_changeyaw(); // OUCH OUCH: its relay on what ent == self ? I'm not even mention about PR2...
 
@@ -238,13 +238,13 @@ qbool SV_StepDirection (edict_t *ent, float yaw, float dist)
 	move[1] = sin(yaw)*dist;
 	move[2] = 0;
 
-	VectorCopy (ent->v.origin, oldorigin);
+	VectorCopy (ent->v->origin, oldorigin);
 	if (SV_movestep (ent, move, false))
 	{
-		delta = ent->v.angles[YAW] - ent->v.ideal_yaw;
+		delta = ent->v->angles[YAW] - ent->v->ideal_yaw;
 		if (delta > 45 && delta < 315)
 		{		// not turned far enough, so don't take the step
-			VectorCopy (oldorigin, ent->v.origin);
+			VectorCopy (oldorigin, ent->v->origin);
 		}
 		SV_LinkEdict (ent, true);
 		return true;
@@ -264,7 +264,7 @@ void SV_FixCheckBottom (edict_t *ent)
 {
 	//	Con_Printf ("SV_FixCheckBottom\n");
 
-	ent->v.flags = (int)ent->v.flags | FL_PARTIALGROUND;
+	ent->v->flags = (int)ent->v->flags | FL_PARTIALGROUND;
 }
 
 
@@ -282,11 +282,11 @@ void SV_NewChaseDir (edict_t *actor, edict_t *enemy, float dist)
 	float			d[3];
 	float		tdir, olddir, turnaround;
 
-	olddir = anglemod( (int)(actor->v.ideal_yaw/45)*45 );
+	olddir = anglemod( (int)(actor->v->ideal_yaw/45)*45 );
 	turnaround = anglemod(olddir - 180);
 
-	deltax = enemy->v.origin[0] - actor->v.origin[0];
-	deltay = enemy->v.origin[1] - actor->v.origin[1];
+	deltax = enemy->v->origin[0] - actor->v->origin[0];
+	deltay = enemy->v->origin[1] - actor->v->origin[1];
 	if (deltax>10)
 		d[1]= 0;
 	else if (deltax<-10)
@@ -349,7 +349,7 @@ void SV_NewChaseDir (edict_t *actor, edict_t *enemy, float dist)
 	if (turnaround != DI_NODIR && SV_StepDirection(actor, turnaround, dist) )
 		return;
 
-	actor->v.ideal_yaw = olddir;		// can't move
+	actor->v->ideal_yaw = olddir;		// can't move
 
 	// if a bridge was pulled out from underneath a monster, it may not have
 	// a valid standing position at all
@@ -371,9 +371,9 @@ qbool SV_CloseEnough (edict_t *ent, edict_t *goal, float dist)
 
 	for (i=0 ; i<3 ; i++)
 	{
-		if (goal->v.absmin[i] > ent->v.absmax[i] + dist)
+		if (goal->v->absmin[i] > ent->v->absmax[i] + dist)
 			return false;
-		if (goal->v.absmax[i] < ent->v.absmin[i] - dist)
+		if (goal->v->absmax[i] < ent->v->absmin[i] - dist)
 			return false;
 	}
 	return true;
@@ -394,21 +394,21 @@ void SV_MoveToGoal (void)
 	float		dist;
 
 	ent = PROG_TO_EDICT(pr_global_struct->self);
-	goal = PROG_TO_EDICT(ent->v.goalentity);
+	goal = PROG_TO_EDICT(ent->v->goalentity);
 	dist = G_FLOAT(OFS_PARM0);
 
-	if ( !( (int)ent->v.flags & (FL_ONGROUND|FL_FLY|FL_SWIM) ) )
+	if ( !( (int)ent->v->flags & (FL_ONGROUND|FL_FLY|FL_SWIM) ) )
 	{
 		G_FLOAT(OFS_RETURN) = 0;
 		return;
 	}
 
 	// if the next step hits the enemy, return immediately
-	if ( PROG_TO_EDICT(ent->v.enemy) != sv.edicts && SV_CloseEnough (ent, goal, dist) )
+	if ( PROG_TO_EDICT(ent->v->enemy) != sv.edicts && SV_CloseEnough (ent, goal, dist) )
 		return;
 
 	// bump around...
-	if ( (rand()&3)==1 || !SV_StepDirection (ent, ent->v.ideal_yaw, dist))
+	if ( (rand()&3)==1 || !SV_StepDirection (ent, ent->v->ideal_yaw, dist))
 	{
 		SV_NewChaseDir (ent, goal, dist);
 	}

--- a/src/sv_phys.c
+++ b/src/sv_phys.c
@@ -93,28 +93,28 @@ void SV_CheckVelocity (edict_t *ent)
 	//
 	for (i=0 ; i<3 ; i++)
 	{
-		if (IS_NAN(ent->v.velocity[i]))
+		if (IS_NAN(ent->v->velocity[i]))
 		{
-			Con_DPrintf ("Got a NaN velocity on %s\n", PR_GetEntityString(ent->v.classname));
-			ent->v.velocity[i] = 0;
+			Con_DPrintf ("Got a NaN velocity on %s\n", PR_GetEntityString(ent->v->classname));
+			ent->v->velocity[i] = 0;
 		}
-		if (IS_NAN(ent->v.origin[i]))
+		if (IS_NAN(ent->v->origin[i]))
 		{
-			Con_DPrintf ("Got a NaN origin on %s\n", PR_GetEntityString(ent->v.classname));
-			ent->v.origin[i] = 0;
+			Con_DPrintf ("Got a NaN origin on %s\n", PR_GetEntityString(ent->v->classname));
+			ent->v->origin[i] = 0;
 		}
-/*		if (ent->v.velocity[i] > sv_maxvelocity.value)
-			ent->v.velocity[i] = sv_maxvelocity.value;
-		else if (ent->v.velocity[i] < -sv_maxvelocity.value)
-			ent->v.velocity[i] = -sv_maxvelocity.value;
+/*		if (ent->v->velocity[i] > sv_maxvelocity.value)
+			ent->v->velocity[i] = sv_maxvelocity.value;
+		else if (ent->v->velocity[i] < -sv_maxvelocity.value)
+			ent->v->velocity[i] = -sv_maxvelocity.value;
 */
 	}
 
 	// SV_MAXVELOCITY fix by Maddes
-	wishspeed = VectorLength(ent->v.velocity);
+	wishspeed = VectorLength(ent->v->velocity);
 	if (wishspeed > sv_maxvelocity.value)
 	{
-		VectorScale (ent->v.velocity, sv_maxvelocity.value/wishspeed, ent->v.velocity);
+		VectorScale (ent->v->velocity, sv_maxvelocity.value/wishspeed, ent->v->velocity);
 		wishspeed = sv_maxvelocity.value;
 	}
 }
@@ -135,7 +135,7 @@ qbool SV_RunThink (edict_t *ent)
 
 	do
 	{
-		thinktime = ent->v.nextthink;
+		thinktime = ent->v->nextthink;
 		if (thinktime <= 0)
 			return true;
 		if (thinktime > sv.time + sv_frametime)
@@ -145,13 +145,13 @@ qbool SV_RunThink (edict_t *ent)
 			thinktime = sv.time; // don't let things stay in the past.
 		// it is possible to start that way
 		// by a trigger with a local time.
-		ent->v.nextthink = 0;
+		ent->v->nextthink = 0;
 		pr_global_struct->time = thinktime;
 		pr_global_struct->self = EDICT_TO_PROG(ent);
 		pr_global_struct->other = EDICT_TO_PROG(sv.edicts);
-		PR_EdictThink(ent->v.think);
+		PR_EdictThink(ent->v->think);
 
-		if (ent->e->free)
+		if (ent->e.free)
 			return false;
 	} while (1);
 
@@ -173,18 +173,18 @@ void SV_Impact (edict_t *e1, edict_t *e2)
 	old_other = pr_global_struct->other;
 
 	pr_global_struct->time = sv.time;
-	if (e1->v.touch && e1->v.solid != SOLID_NOT)
+	if (e1->v->touch && e1->v->solid != SOLID_NOT)
 	{
 		pr_global_struct->self = EDICT_TO_PROG(e1);
 		pr_global_struct->other = EDICT_TO_PROG(e2);
-		PR_EdictTouch(e1->v.touch);
+		PR_EdictTouch(e1->v->touch);
 	}
 
-	if (e2->v.touch && e2->v.solid != SOLID_NOT)
+	if (e2->v->touch && e2->v->solid != SOLID_NOT)
 	{
 		pr_global_struct->self = EDICT_TO_PROG(e2);
 		pr_global_struct->other = EDICT_TO_PROG(e1);
-		PR_EdictTouch(e2->v.touch);
+		PR_EdictTouch(e2->v->touch);
 	}
 
 	pr_global_struct->self = old_self;
@@ -250,8 +250,8 @@ int SV_FlyMove (edict_t *ent, float time1, trace_t *steptrace, int type)
 	numbumps = 4;
 
 	blocked = 0;
-	VectorCopy (ent->v.velocity, original_velocity);
-	VectorCopy (ent->v.velocity, primal_velocity);
+	VectorCopy (ent->v->velocity, original_velocity);
+	VectorCopy (ent->v->velocity, primal_velocity);
 	numplanes = 0;
 
 	time_left = time1;
@@ -259,20 +259,20 @@ int SV_FlyMove (edict_t *ent, float time1, trace_t *steptrace, int type)
 	for (bumpcount=0 ; bumpcount<numbumps ; bumpcount++)
 	{
 		for (i=0 ; i<3 ; i++)
-			end[i] = ent->v.origin[i] + time_left * ent->v.velocity[i];
+			end[i] = ent->v->origin[i] + time_left * ent->v->velocity[i];
 
-		trace = SV_Trace (ent->v.origin, ent->v.mins, ent->v.maxs, end, type, ent);
+		trace = SV_Trace (ent->v->origin, ent->v->mins, ent->v->maxs, end, type, ent);
 
 		if (trace.allsolid)
 		{	// entity is trapped in another solid
-			VectorClear (ent->v.velocity);
+			VectorClear (ent->v->velocity);
 			return 3;
 		}
 
 		if (trace.fraction > 0)
 		{	// actually covered some distance
-			VectorCopy (trace.endpos, ent->v.origin);
-			VectorCopy (ent->v.velocity, original_velocity);
+			VectorCopy (trace.endpos, ent->v->origin);
+			VectorCopy (ent->v->velocity, original_velocity);
 			numplanes = 0;
 		}
 
@@ -285,10 +285,10 @@ int SV_FlyMove (edict_t *ent, float time1, trace_t *steptrace, int type)
 		if (trace.plane.normal[2] > 0.7)
 		{
 			blocked |= 1; // floor
-			if (trace.e.ent->v.solid == SOLID_BSP)
+			if (trace.e.ent->v->solid == SOLID_BSP)
 			{
-				ent->v.flags = (int)ent->v.flags | FL_ONGROUND;
-				ent->v.groundentity = EDICT_TO_PROG(trace.e.ent);
+				ent->v->flags = (int)ent->v->flags | FL_ONGROUND;
+				ent->v->groundentity = EDICT_TO_PROG(trace.e.ent);
 			}
 		}
 		if (!trace.plane.normal[2])
@@ -302,7 +302,7 @@ int SV_FlyMove (edict_t *ent, float time1, trace_t *steptrace, int type)
 		// run the impact function
 		//
 		SV_Impact (ent, trace.e.ent);
-		if (ent->e->free)
+		if (ent->e.free)
 			break;	 // removed by the impact function
 
 
@@ -311,7 +311,7 @@ int SV_FlyMove (edict_t *ent, float time1, trace_t *steptrace, int type)
 		// cliped to another plane
 		if (numplanes >= MAX_CLIP_PLANES)
 		{	// this shouldn't really happen
-			VectorClear (ent->v.velocity);
+			VectorClear (ent->v->velocity);
 			return 3;
 		}
 
@@ -336,28 +336,28 @@ int SV_FlyMove (edict_t *ent, float time1, trace_t *steptrace, int type)
 
 		if (i != numplanes)
 		{	// go along this plane
-			VectorCopy (new_velocity, ent->v.velocity);
+			VectorCopy (new_velocity, ent->v->velocity);
 		}
 		else
 		{	// go along the crease
 			if (numplanes != 2)
 			{
 				// Con_Printf ("clip velocity, numplanes == %i\n",numplanes);
-				VectorClear (ent->v.velocity);
+				VectorClear (ent->v->velocity);
 				return 7;
 			}
 			CrossProduct (planes[0], planes[1], dir);
-			d = DotProduct (dir, ent->v.velocity);
-			VectorScale (dir, d, ent->v.velocity);
+			d = DotProduct (dir, ent->v->velocity);
+			VectorScale (dir, d, ent->v->velocity);
 		}
 
 		//
 		// if original velocity is against the original velocity, stop dead
 		// to avoid tiny occilations in sloping corners
 		//
-		if (DotProduct (ent->v.velocity, primal_velocity) <= 0)
+		if (DotProduct (ent->v->velocity, primal_velocity) <= 0)
 		{
-			VectorClear (ent->v.velocity);
+			VectorClear (ent->v->velocity);
 			return blocked;
 		}
 	}
@@ -373,7 +373,7 @@ SV_AddGravity
 */
 void SV_AddGravity (edict_t *ent, float scale)
 {
-	ent->v.velocity[2] -= scale * movevars.gravity * sv_frametime;
+	ent->v->velocity[2] -= scale * movevars.gravity * sv_frametime;
 }
 
 /*
@@ -396,20 +396,20 @@ trace_t SV_PushEntity (edict_t *ent, vec3_t push, unsigned int traceflags)
 	trace_t	trace;
 	vec3_t	end;
 
-	VectorAdd (ent->v.origin, push, end);
+	VectorAdd (ent->v->origin, push, end);
 
-	if ((int)ent->v.flags&FL_LAGGEDMOVE)
+	if ((int)ent->v->flags&FL_LAGGEDMOVE)
 		traceflags |= MOVE_LAGGED;
 
-	if (ent->v.movetype == MOVETYPE_FLYMISSILE)
-		trace = SV_Trace (ent->v.origin, ent->v.mins, ent->v.maxs, end, MOVE_MISSILE|traceflags, ent);
-	else if (ent->v.solid == SOLID_TRIGGER || ent->v.solid == SOLID_NOT)
+	if (ent->v->movetype == MOVETYPE_FLYMISSILE)
+		trace = SV_Trace (ent->v->origin, ent->v->mins, ent->v->maxs, end, MOVE_MISSILE|traceflags, ent);
+	else if (ent->v->solid == SOLID_TRIGGER || ent->v->solid == SOLID_NOT)
 		// only clip against bmodels
-		trace = SV_Trace (ent->v.origin, ent->v.mins, ent->v.maxs, end, MOVE_NOMONSTERS|traceflags, ent);
+		trace = SV_Trace (ent->v->origin, ent->v->mins, ent->v->maxs, end, MOVE_NOMONSTERS|traceflags, ent);
 	else
-		trace = SV_Trace (ent->v.origin, ent->v.mins, ent->v.maxs, end, MOVE_NORMAL|traceflags, ent);
+		trace = SV_Trace (ent->v->origin, ent->v->mins, ent->v->maxs, end, MOVE_NORMAL|traceflags, ent);
 
-	VectorCopy (trace.endpos, ent->v.origin);
+	VectorCopy (trace.endpos, ent->v->origin);
 	SV_LinkEdict (ent, true);
 
 	if (trace.e.ent)
@@ -438,15 +438,15 @@ qbool SV_Push (edict_t *pusher, vec3_t move)
 
 	for (i=0 ; i<3 ; i++)
 	{
-		mins[i] = pusher->v.absmin[i] + move[i];
-		maxs[i] = pusher->v.absmax[i] + move[i];
+		mins[i] = pusher->v->absmin[i] + move[i];
+		maxs[i] = pusher->v->absmax[i] + move[i];
 	}
 
-	VectorCopy (pusher->v.origin, pushorig);
+	VectorCopy (pusher->v->origin, pushorig);
 
 	// move the pusher to its final position
 
-	VectorAdd (pusher->v.origin, move, pusher->v.origin);
+	VectorAdd (pusher->v->origin, move, pusher->v->origin);
 	SV_LinkEdict (pusher, false);
 
 	// see if any solid entities are inside the final position
@@ -454,30 +454,30 @@ qbool SV_Push (edict_t *pusher, vec3_t move)
 	check = NEXT_EDICT(sv.edicts);
 	for (e=1 ; e<sv.num_edicts ; e++, check = NEXT_EDICT(check))
 	{
-		if (check->e->free)
+		if (check->e.free)
 			continue;
-		if (check->v.movetype == MOVETYPE_PUSH
-		|| check->v.movetype == MOVETYPE_NONE
-		|| check->v.movetype == MOVETYPE_NOCLIP)
+		if (check->v->movetype == MOVETYPE_PUSH
+		|| check->v->movetype == MOVETYPE_NONE
+		|| check->v->movetype == MOVETYPE_NOCLIP)
 			continue;
 
-		solid_save = pusher->v.solid;
-		pusher->v.solid = SOLID_NOT;
+		solid_save = pusher->v->solid;
+		pusher->v->solid = SOLID_NOT;
 		block = SV_TestEntityPosition (check);
-		pusher->v.solid = solid_save;
+		pusher->v->solid = solid_save;
 		if (block)
 			continue;
 
 		// if the entity is standing on the pusher, it will definately be moved
-		if ( ! ( ((int)check->v.flags & FL_ONGROUND)
-		&& PROG_TO_EDICT(check->v.groundentity) == pusher) )
+		if ( ! ( ((int)check->v->flags & FL_ONGROUND)
+		&& PROG_TO_EDICT(check->v->groundentity) == pusher) )
 		{
-			if ( check->v.absmin[0] >= maxs[0]
-			|| check->v.absmin[1] >= maxs[1]
-			|| check->v.absmin[2] >= maxs[2]
-			|| check->v.absmax[0] <= mins[0]
-			|| check->v.absmax[1] <= mins[1]
-			|| check->v.absmax[2] <= mins[2] )
+			if ( check->v->absmin[0] >= maxs[0]
+			|| check->v->absmin[1] >= maxs[1]
+			|| check->v->absmin[2] >= maxs[2]
+			|| check->v->absmax[0] <= mins[0]
+			|| check->v->absmax[1] <= mins[1]
+			|| check->v->absmax[2] <= mins[2] )
 				continue;
 
 			// see if the ent's bbox is inside the pusher's final position
@@ -486,15 +486,15 @@ qbool SV_Push (edict_t *pusher, vec3_t move)
 		}
 
 		// remove the onground flag for non-players
-		if (check->v.movetype != MOVETYPE_WALK)
-			check->v.flags = (int)check->v.flags & ~FL_ONGROUND;
+		if (check->v->movetype != MOVETYPE_WALK)
+			check->v->flags = (int)check->v->flags & ~FL_ONGROUND;
 
-		VectorCopy (check->v.origin, moved_from[num_moved]);
+		VectorCopy (check->v->origin, moved_from[num_moved]);
 		moved_edict[num_moved] = check;
 		num_moved++;
 
 		// try moving the contacted entity
-		VectorAdd (check->v.origin, move, check->v.origin);
+		VectorAdd (check->v->origin, move, check->v->origin);
 		block = SV_TestEntityPosition (check);
 		if (!block)
 		{	// pushed ok
@@ -503,7 +503,7 @@ qbool SV_Push (edict_t *pusher, vec3_t move)
 		}
 
 		// if it is ok to leave in the old position, do it
-		VectorSubtract (check->v.origin, move, check->v.origin);
+		VectorSubtract (check->v->origin, move, check->v->origin);
 		block = SV_TestEntityPosition (check);
 		if (!block)
 		{
@@ -515,35 +515,35 @@ qbool SV_Push (edict_t *pusher, vec3_t move)
 		}
 
 		// if it is still inside the pusher, block
-		if (check->v.mins[0] == check->v.maxs[0])
+		if (check->v->mins[0] == check->v->maxs[0])
 		{
 			SV_LinkEdict (check, false);
 			continue;
 		}
-		if (check->v.solid == SOLID_NOT || check->v.solid == SOLID_TRIGGER)
+		if (check->v->solid == SOLID_NOT || check->v->solid == SOLID_TRIGGER)
 		{	// corpse
-			check->v.mins[0] = check->v.mins[1] = 0;
-			VectorCopy (check->v.mins, check->v.maxs);
+			check->v->mins[0] = check->v->mins[1] = 0;
+			VectorCopy (check->v->mins, check->v->maxs);
 			SV_LinkEdict (check, false);
 			continue;
 		}
 
-		VectorCopy (pushorig, pusher->v.origin);
+		VectorCopy (pushorig, pusher->v->origin);
 		SV_LinkEdict (pusher, false);
 
 		// if the pusher has a "blocked" function, call it
 		// otherwise, just stay in place until the obstacle is gone
-		if (pusher->v.blocked)
+		if (pusher->v->blocked)
 		{
 			pr_global_struct->self = EDICT_TO_PROG(pusher);
 			pr_global_struct->other = EDICT_TO_PROG(check);
-			PR_EdictBlocked (pusher->v.blocked);
+			PR_EdictBlocked (pusher->v->blocked);
 		}
 
 		// move back any entities we already moved
 		for (i=0 ; i<num_moved ; i++)
 		{
-			VectorCopy (moved_from[i], moved_edict[i]->v.origin);
+			VectorCopy (moved_from[i], moved_edict[i]->v->origin);
 			SV_LinkEdict (moved_edict[i], false);
 		}
 		return false;
@@ -563,17 +563,17 @@ void SV_PushMove (edict_t *pusher, float movetime)
 	int i;
 	vec3_t move;
 
-	if (!pusher->v.velocity[0] && !pusher->v.velocity[1] && !pusher->v.velocity[2])
+	if (!pusher->v->velocity[0] && !pusher->v->velocity[1] && !pusher->v->velocity[2])
 	{
-		pusher->v.ltime += movetime;
+		pusher->v->ltime += movetime;
 		return;
 	}
 
 	for (i=0 ; i<3 ; i++)
-		move[i] = pusher->v.velocity[i] * movetime;
+		move[i] = pusher->v->velocity[i] * movetime;
 
 	if (SV_Push (pusher, move))
-		pusher->v.ltime += movetime;
+		pusher->v->ltime += movetime;
 }
 
 
@@ -591,12 +591,12 @@ void SV_Physics_Pusher (edict_t *ent)
 	float l;
 	vec3_t oldorg, move;
 
-	oldltime = ent->v.ltime;
+	oldltime = ent->v->ltime;
 
-	thinktime = ent->v.nextthink;
-	if (thinktime < ent->v.ltime + sv_frametime)
+	thinktime = ent->v->nextthink;
+	if (thinktime < ent->v->ltime + sv_frametime)
 	{
-		movetime = thinktime - ent->v.ltime;
+		movetime = thinktime - ent->v->ltime;
 		if (movetime < 0)
 			movetime = 0;
 	}
@@ -605,27 +605,27 @@ void SV_Physics_Pusher (edict_t *ent)
 
 	if (movetime)
 	{
-		SV_PushMove (ent, movetime);	// advances ent->v.ltime if not blocked
+		SV_PushMove (ent, movetime);	// advances ent->v->ltime if not blocked
 	}
 
-	if (thinktime > oldltime && thinktime <= ent->v.ltime)
+	if (thinktime > oldltime && thinktime <= ent->v->ltime)
 	{
-		VectorCopy (ent->v.origin, oldorg);
-		ent->v.nextthink = 0;
+		VectorCopy (ent->v->origin, oldorg);
+		ent->v->nextthink = 0;
 		pr_global_struct->time = sv.time;
 		pr_global_struct->self = EDICT_TO_PROG(ent);
 		pr_global_struct->other = EDICT_TO_PROG(sv.edicts);
-		PR_EdictThink(ent->v.think);
+		PR_EdictThink(ent->v->think);
 
-		if (ent->e->free)
+		if (ent->e.free)
 			return;
-		VectorSubtract (ent->v.origin, oldorg, move);
+		VectorSubtract (ent->v->origin, oldorg, move);
 
 		l = VectorLength(move);
 		if (l > 1.0/64)
 		{
 			// Con_Printf ("**** snap: %f\n", VectorLength (l));
-			VectorCopy (oldorg, ent->v.origin);
+			VectorCopy (oldorg, ent->v->origin);
 			SV_Push (ent, move);
 		}
 	}
@@ -657,8 +657,8 @@ void SV_Physics_Noclip (edict_t *ent)
 	if (!SV_RunThink (ent))
 		return;
 
-	VectorMA (ent->v.angles, sv_frametime, ent->v.avelocity, ent->v.angles);
-	VectorMA (ent->v.origin, sv_frametime, ent->v.velocity, ent->v.origin);
+	VectorMA (ent->v->angles, sv_frametime, ent->v->avelocity, ent->v->angles);
+	VectorMA (ent->v->origin, sv_frametime, ent->v->velocity, ent->v->origin);
 
 	SV_LinkEdict (ent, false);
 }
@@ -681,31 +681,31 @@ void SV_CheckWaterTransition (edict_t *ent)
 {
 	int cont;
 
-	cont = SV_PointContents (ent->v.origin);
-	if (!ent->v.watertype)
+	cont = SV_PointContents (ent->v->origin);
+	if (!ent->v->watertype)
 	{	// just spawned here
-		ent->v.watertype = cont;
-		ent->v.waterlevel = 1;
+		ent->v->watertype = cont;
+		ent->v->waterlevel = 1;
 		return;
 	}
 
 	if (cont <= CONTENTS_WATER)
 	{
-		if (ent->v.watertype == CONTENTS_EMPTY)
+		if (ent->v->watertype == CONTENTS_EMPTY)
 		{	// just crossed into water
 			SV_StartSound (ent, 0, "misc/h2ohit1.wav", 255, 1);
 		}
-		ent->v.watertype = cont;
-		ent->v.waterlevel = 1;
+		ent->v->watertype = cont;
+		ent->v->waterlevel = 1;
 	}
 	else
 	{
-		if (ent->v.watertype != CONTENTS_EMPTY)
+		if (ent->v->watertype != CONTENTS_EMPTY)
 		{	// just crossed into water
 			SV_StartSound (ent, 0, "misc/h2ohit1.wav", 255, 1);
 		}
-		ent->v.watertype = CONTENTS_EMPTY;
-		ent->v.waterlevel = cont;
+		ent->v->watertype = CONTENTS_EMPTY;
+		ent->v->waterlevel = cont;
 	}
 }
 
@@ -726,47 +726,47 @@ void SV_Physics_Toss (edict_t *ent)
 	if (!SV_RunThink (ent))
 		return;
 
-	if (ent->v.velocity[2] > 0)
-		ent->v.flags = (int)ent->v.flags & ~FL_ONGROUND;
+	if (ent->v->velocity[2] > 0)
+		ent->v->flags = (int)ent->v->flags & ~FL_ONGROUND;
 
 	// if onground, return without moving
-	if ( ((int)ent->v.flags & FL_ONGROUND) )
+	if ( ((int)ent->v->flags & FL_ONGROUND) )
 		return;
 
 	SV_CheckVelocity (ent);
 
 	// add gravity
-	if (ent->v.movetype != MOVETYPE_FLY
-	&& ent->v.movetype != MOVETYPE_FLYMISSILE)
+	if (ent->v->movetype != MOVETYPE_FLY
+	&& ent->v->movetype != MOVETYPE_FLYMISSILE)
 		SV_AddGravity (ent, 1.0);
 
 	// move angles
-	VectorMA (ent->v.angles, sv_frametime, ent->v.avelocity, ent->v.angles);
+	VectorMA (ent->v->angles, sv_frametime, ent->v->avelocity, ent->v->angles);
 
 	// move origin
-	VectorScale (ent->v.velocity, sv_frametime, move);
+	VectorScale (ent->v->velocity, sv_frametime, move);
 	trace = SV_PushEntity (ent, move, (sv_antilag.value == 2 && sv_antilag_projectiles.value) ? MOVE_LAGGED:0);
 	if (trace.fraction == 1)
 		return;
-	if (ent->e->free)
+	if (ent->e.free)
 		return;
 
-	if (ent->v.movetype == MOVETYPE_BOUNCE)
+	if (ent->v->movetype == MOVETYPE_BOUNCE)
 		backoff = 1.5;
 	else
 		backoff = 1;
 
-	ClipVelocity (ent->v.velocity, trace.plane.normal, ent->v.velocity, backoff);
+	ClipVelocity (ent->v->velocity, trace.plane.normal, ent->v->velocity, backoff);
 
 	// stop if on ground
 	if (trace.plane.normal[2] > 0.7)
 	{
-		if (ent->v.velocity[2] < 60 || ent->v.movetype != MOVETYPE_BOUNCE )
+		if (ent->v->velocity[2] < 60 || ent->v->movetype != MOVETYPE_BOUNCE )
 		{
-			ent->v.flags = (int)ent->v.flags | FL_ONGROUND;
-			ent->v.groundentity = EDICT_TO_PROG(trace.e.ent);
-			VectorClear (ent->v.velocity);
-			VectorClear (ent->v.avelocity);
+			ent->v->flags = (int)ent->v->flags | FL_ONGROUND;
+			ent->v->groundentity = EDICT_TO_PROG(trace.e.ent);
+			VectorClear (ent->v->velocity);
+			VectorClear (ent->v->avelocity);
 		}
 	}
 
@@ -799,9 +799,9 @@ void SV_Physics_Step (edict_t *ent)
 	qbool hitsound;
 
 	// frefall if not onground
-	if ( ! ((int)ent->v.flags & (FL_ONGROUND | FL_FLY | FL_SWIM) ) )
+	if ( ! ((int)ent->v->flags & (FL_ONGROUND | FL_FLY | FL_SWIM) ) )
 	{
-		if (ent->v.velocity[2] < movevars.gravity*-0.1)
+		if (ent->v->velocity[2] < movevars.gravity*-0.1)
 			hitsound = true;
 		else
 			hitsound = false;
@@ -811,13 +811,13 @@ void SV_Physics_Step (edict_t *ent)
 		// Tonik: the check for SOLID_NOT is to fix the way dead bodies and
 		// gibs behave (should not be blocked by players & monsters);
 		// The SOLID_TRIGGER check is disabled lest we break frikbots
-		if (ent->v.solid == SOLID_NOT /* || ent->v.solid == SOLID_TRIGGER*/)
+		if (ent->v->solid == SOLID_NOT /* || ent->v->solid == SOLID_TRIGGER*/)
 			SV_FlyMove (ent, sv_frametime, NULL, MOVE_NOMONSTERS);
 		else
 			SV_FlyMove (ent, sv_frametime, NULL, MOVE_NORMAL);
 		SV_LinkEdict (ent, true);
 
-		if ( (int)ent->v.flags & FL_ONGROUND ) // just hit ground
+		if ( (int)ent->v->flags & FL_ONGROUND ) // just hit ground
 		{
 			if (hitsound)
 				SV_StartSound (ent, 0, "demon/dland2.wav", 255, 1);
@@ -848,11 +848,11 @@ SV_RunEntity
 */
 void SV_RunEntity (edict_t *ent)
 {
-	if (ent->e->lastruntime == sv.time)
+	if (ent->e.lastruntime == sv.time)
 		return;
-	ent->e->lastruntime = sv.time;
+	ent->e.lastruntime = sv.time;
 
-	switch ((int)ent->v.movetype)
+	switch ((int)ent->v->movetype)
 	{
 	case MOVETYPE_PUSH:
 		SV_Physics_Pusher (ent);
@@ -874,7 +874,7 @@ void SV_RunEntity (edict_t *ent)
 		SV_Physics_Toss (ent);
 		break;
 	default:
-		SV_Error ("SV_Physics: bad movetype %i", (int)ent->v.movetype);
+		SV_Error ("SV_Physics: bad movetype %i", (int)ent->v->movetype);
 	}
 }
 
@@ -893,15 +893,15 @@ void SV_RunNQNewmis (void)
 	ent = NEXT_EDICT(sv.edicts);
 	for (i=1 ; i<sv.num_edicts ; i++, ent = NEXT_EDICT(ent))
 	{
-		if (ent->e->free)
+		if (ent->e.free)
 			continue;
-		if (ent->e->lastruntime || ent->v.owner != pl)
+		if (ent->e.lastruntime || ent->v->owner != pl)
 			continue;
-		if (ent->v.movetype != MOVETYPE_FLY &&
-			ent->v.movetype != MOVETYPE_FLYMISSILE && 
-			ent->v.movetype != MOVETYPE_BOUNCE) 
+		if (ent->v->movetype != MOVETYPE_FLY &&
+			ent->v->movetype != MOVETYPE_FLYMISSILE && 
+			ent->v->movetype != MOVETYPE_BOUNCE) 
 			continue;
-		if (ent->v.solid != SOLID_BBOX && ent->v.solid != SOLID_TRIGGER)
+		if (ent->v->solid != SOLID_BBOX && ent->v->solid != SOLID_TRIGGER)
 			continue;
 
 		save_frametime = sv_frametime;
@@ -983,7 +983,7 @@ void SV_Physics (void)
 	ent = sv.edicts;
 	for (i=0 ; i<sv.num_edicts ; i++, ent = NEXT_EDICT(ent))
 	{
-		if (ent->e->free)
+		if (ent->e.free)
 			continue;
 
 		if (PR_GLOBAL(force_retouch))
@@ -1012,7 +1012,7 @@ void SV_Physics (void)
 		sv_player = cl->edict;
 
 		if (sv_client->spectator && sv_client->spec_track > 0)
-			sv_player->v.goalentity = EDICT_TO_PROG(svs.clients[sv_client->spec_track-1].edict);
+			sv_player->v->goalentity = EDICT_TO_PROG(svs.clients[sv_client->spec_track-1].edict);
 	}
 
 	sv_player = savesvpl;
@@ -1102,7 +1102,7 @@ void SV_RunBots(void)
 		if (sv_antilag.value) {
 			if (cl->antilag_position_next == 0 || cl->antilag_positions[(cl->antilag_position_next - 1) % MAX_ANTILAG_POSITIONS].localtime < cl->localtime) {
 				cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].localtime = cl->localtime;
-				VectorCopy(cl->edict->v.origin, cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].origin);
+				VectorCopy(cl->edict->v->origin, cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].origin);
 				cl->antilag_position_next++;
 			}
 		}

--- a/src/sv_save.c
+++ b/src/sv_save.c
@@ -109,7 +109,7 @@ void SV_SaveGame_f(void)
 	if (svs.clients[0].state != cs_spawned) {
 		Con_Printf ("Can't save, client #0 not spawned.\n");
 		return;
-	} else if (svs.clients[0].edict->v.health <= 0) {
+	} else if (svs.clients[0].edict->v->health <= 0) {
 		Con_Printf ("Can't save game with a dead player\n");
 		// in fact, we can, but does it make sense?
 		return;
@@ -290,7 +290,7 @@ void SV_LoadGame_f(void)
 			ED_ParseEdict (start, ent);
 
 			// link it into the bsp tree
-			if (!ent->e->free)
+			if (!ent->e.free)
 				SV_LinkEdict (ent, false);
 		}
 		entnum++;

--- a/src/sv_send.c
+++ b/src/sv_send.c
@@ -450,18 +450,18 @@ void SV_MulticastEx (vec3_t origin, int to, const char *cl_reliable_key)
 		// in case of trackent we have to reflect his origin so PHS work right.
 		if (fofs_trackent)
 		{
-			trackent = ((eval_t *)((byte *)&(client->edict)->v + fofs_trackent))->_int;
+			trackent = ((eval_t *)((byte *)(client->edict)->v + fofs_trackent))->_int;
 			if (trackent < 1 || trackent > MAX_CLIENTS || svs.clients[trackent - 1].state != cs_spawned)
 				trackent = 0;
 		}
 
 		if (trackent)
 		{
-			VectorAdd (svs.clients[trackent - 1].edict->v.origin, svs.clients[trackent - 1].edict->v.view_ofs, vieworg);
+			VectorAdd (svs.clients[trackent - 1].edict->v->origin, svs.clients[trackent - 1].edict->v->view_ofs, vieworg);
 		}
 		else
 		{
-			VectorAdd (client->edict->v.origin, client->edict->v.view_ofs, vieworg);
+			VectorAdd (client->edict->v->origin, client->edict->v->view_ofs, vieworg);
 		}
 
 		if (to == MULTICAST_PHS_R || to == MULTICAST_PHS)
@@ -631,14 +631,14 @@ void SV_StartSound (edict_t *entity, int channel, char *sample, int volume, floa
 		channel |= SND_ATTENUATION;
 
 	// use the entity origin unless it is a bmodel
-	if (entity->v.solid == SOLID_BSP)
+	if (entity->v->solid == SOLID_BSP)
 	{
 		for (i=0 ; i<3 ; i++)
-			origin[i] = entity->v.origin[i]+0.5*(entity->v.mins[i]+entity->v.maxs[i]);
+			origin[i] = entity->v->origin[i]+0.5*(entity->v->mins[i]+entity->v->maxs[i]);
 	}
 	else
 	{
-		VectorCopy (entity->v.origin, origin);
+		VectorCopy (entity->v->origin, origin);
 	}
 
 	MSG_WriteByte (&sv.multicast, svc_sound);
@@ -715,17 +715,17 @@ void SV_WriteClientdataToMessage (client_t *client, sizebuf_t *msg)
 	}
 
 	// send a damage message if the player got hit this frame
-	if (ent->v.dmg_take || ent->v.dmg_save)
+	if (ent->v->dmg_take || ent->v->dmg_save)
 	{
-		other = PROG_TO_EDICT(ent->v.dmg_inflictor);
+		other = PROG_TO_EDICT(ent->v->dmg_inflictor);
 		MSG_WriteByte (msg, svc_damage);
-		MSG_WriteByte (msg, ent->v.dmg_save);
-		MSG_WriteByte (msg, ent->v.dmg_take);
+		MSG_WriteByte (msg, ent->v->dmg_save);
+		MSG_WriteByte (msg, ent->v->dmg_take);
 		for (i=0 ; i<3 ; i++)
-			MSG_WriteCoord (msg, other->v.origin[i] + 0.5*(other->v.mins[i] + other->v.maxs[i]));
+			MSG_WriteCoord (msg, other->v->origin[i] + 0.5*(other->v->mins[i] + other->v->maxs[i]));
 
-		ent->v.dmg_take = 0;
-		ent->v.dmg_save = 0;
+		ent->v->dmg_take = 0;
+		ent->v->dmg_save = 0;
 	}
 
 	// add this to server demo
@@ -738,16 +738,16 @@ void SV_WriteClientdataToMessage (client_t *client, sizebuf_t *msg)
 	}
 
 	// a fixangle might get lost in a dropped packet.  Oh well.
-	if (ent->v.fixangle)
+	if (ent->v->fixangle)
 	{
-		ent->v.fixangle = 0;
+		ent->v->fixangle = 0;
 		demo.fixangle[clnum] = true;
 
 		MSG_WriteByte (msg, svc_setangle);
 
 		if (client->mvdprotocolextensions1 & MVD_PEXT1_HIGHLAGTELEPORT) {
 			if (fofs_teleported) {
-				client->lastteleport_teleport = ((eval_t *)((byte *)&(client->edict)->v + fofs_teleported))->_int;
+				client->lastteleport_teleport = ((eval_t *)((byte *)(client->edict)->v + fofs_teleported))->_int;
 				if (client->lastteleport_teleport) {
 					MSG_WriteByte(msg, 1); // signal a teleport
 				}
@@ -756,9 +756,9 @@ void SV_WriteClientdataToMessage (client_t *client, sizebuf_t *msg)
 				}
 				client->lastteleport_outgoingseq = client->netchan.outgoing_sequence;
 				client->lastteleport_incomingseq = client->netchan.incoming_sequence;
-				client->lastteleport_teleportyaw = (client->edict)->v.angles[YAW] - client->lastcmd.angles[YAW];
+				client->lastteleport_teleportyaw = (client->edict)->v->angles[YAW] - client->lastcmd.angles[YAW];
 
-				((eval_t *)((byte *)&(client->edict)->v + fofs_teleported))->_int = 0;
+				((eval_t *)((byte *)(client->edict)->v + fofs_teleported))->_int = 0;
 				SV_RotateCmd(client, &client->lastcmd);
 			}
 			else {
@@ -767,14 +767,14 @@ void SV_WriteClientdataToMessage (client_t *client, sizebuf_t *msg)
 		}
 
 		for (i=0 ; i < 3 ; i++)
-			MSG_WriteAngle (msg, ent->v.angles[i] );
+			MSG_WriteAngle (msg, ent->v->angles[i] );
 
 		if (sv.mvdrecording)
 		{
 			MSG_WriteByte (&demo.datagram, svc_setangle);
 			MSG_WriteByte (&demo.datagram, clnum);
 			for (i=0 ; i < 3 ; i++)
-				MSG_WriteAngle (&demo.datagram, ent->v.angles[i] );
+				MSG_WriteAngle (&demo.datagram, ent->v->angles[i] );
 		}
 	}
 
@@ -833,7 +833,7 @@ void SV_UpdateClientStats (client_t *client)
 	// in case of trackent we have to reflect his stats like for spectator.
 	if (fofs_trackent)
 	{
-		int trackent = ((eval_t *)((byte *)&(client->edict)->v + fofs_trackent))->_int;
+		int trackent = ((eval_t *)((byte *)(client->edict)->v + fofs_trackent))->_int;
 		if (trackent < 1 || trackent > MAX_CLIENTS || svs.clients[trackent - 1].state != cs_spawned)
 			trackent = 0;
 
@@ -841,23 +841,23 @@ void SV_UpdateClientStats (client_t *client)
 			ent = svs.clients[trackent - 1].edict;
 	}
 
-	stats[STAT_HEALTH] = ent->v.health;
-	stats[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v.weaponmodel));
-	stats[STAT_AMMO] = ent->v.currentammo;
-	stats[STAT_ARMOR] = ent->v.armorvalue;
-	stats[STAT_SHELLS] = ent->v.ammo_shells;
-	stats[STAT_NAILS] = ent->v.ammo_nails;
-	stats[STAT_ROCKETS] = ent->v.ammo_rockets;
-	stats[STAT_CELLS] = ent->v.ammo_cells;
+	stats[STAT_HEALTH] = ent->v->health;
+	stats[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v->weaponmodel));
+	stats[STAT_AMMO] = ent->v->currentammo;
+	stats[STAT_ARMOR] = ent->v->armorvalue;
+	stats[STAT_SHELLS] = ent->v->ammo_shells;
+	stats[STAT_NAILS] = ent->v->ammo_nails;
+	stats[STAT_ROCKETS] = ent->v->ammo_rockets;
+	stats[STAT_CELLS] = ent->v->ammo_cells;
 	if (!client->spectator || client->spec_track > 0)
-		stats[STAT_ACTIVEWEAPON] = ent->v.weapon;
+		stats[STAT_ACTIVEWEAPON] = ent->v->weapon;
 	// stuff the sigil bits into the high bits of items for sbar
-	stats[STAT_ITEMS] = (int) ent->v.items | ((int) PR_GLOBAL(serverflags) << 28);
+	stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 	if (fofs_items2)	// ZQ_ITEMS2 extension
 		stats[STAT_ITEMS] |= (int)EdictFieldFloat(ent, fofs_items2) << 23;
 
-	if (ent->v.health > 0 || client->spectator) // viewheight for PF_DEAD & PF_GIB is hardwired
-		stats[STAT_VIEWHEIGHT] = ent->v.view_ofs[2];
+	if (ent->v->health > 0 || client->spectator) // viewheight for PF_DEAD & PF_GIB is hardwired
+		stats[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
 
 	for (i=0 ; i<MAX_CL_STATS ; i++)
 		if (stats[i] != client->stats[i])
@@ -968,7 +968,7 @@ static void SV_UpdateToReliableMessages (void)
 
 		ent = sv_client->edict;
 
-		if (sv_client->old_frags != (int)ent->v.frags)
+		if (sv_client->old_frags != (int)ent->v->frags)
 		{
 			for (j=0, client = svs.clients ; j<MAX_CLIENTS ; j++, client++)
 			{
@@ -976,7 +976,7 @@ static void SV_UpdateToReliableMessages (void)
 					continue;
 				ClientReliableWrite_Begin(client, svc_updatefrags, 4);
 				ClientReliableWrite_Byte(client, i);
-				ClientReliableWrite_Short(client, (int) ent->v.frags);
+				ClientReliableWrite_Short(client, (int) ent->v->frags);
 			}
 
 			if (sv.mvdrecording)
@@ -985,11 +985,11 @@ static void SV_UpdateToReliableMessages (void)
 				{
 					MVD_MSG_WriteByte(svc_updatefrags);
 					MVD_MSG_WriteByte(i);
-					MVD_MSG_WriteShort((int)ent->v.frags);
+					MVD_MSG_WriteShort((int)ent->v->frags);
 				}
 			}
 
-			sv_client->old_frags = (int) ent->v.frags;
+			sv_client->old_frags = (int) ent->v->frags;
 		}
 
 		// maxspeed/entgravity changes
@@ -1082,7 +1082,7 @@ void SV_SendClientMessages (void)
 
 	if (fofs_visibility) {
 		for (i = 0; i < MAX_CLIENTS; ++i) {
-			((eval_t *)((byte *)&(svs.clients[i].edict)->v + fofs_visibility))->_int = 0;
+			((eval_t *)((byte *)(svs.clients[i].edict)->v + fofs_visibility))->_int = 0;
 		}
 	}
 
@@ -1218,21 +1218,21 @@ void MVD_WriteStats(void)
 		ent = c->edict;
 		memset (stats, 0, sizeof(stats));
 
-		stats[STAT_HEALTH] = ent->v.health;
-		stats[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v.weaponmodel));
-		stats[STAT_AMMO] = ent->v.currentammo;
-		stats[STAT_ARMOR] = ent->v.armorvalue;
-		stats[STAT_SHELLS] = ent->v.ammo_shells;
-		stats[STAT_NAILS] = ent->v.ammo_nails;
-		stats[STAT_ROCKETS] = ent->v.ammo_rockets;
-		stats[STAT_CELLS] = ent->v.ammo_cells;
-		stats[STAT_ACTIVEWEAPON] = ent->v.weapon;
+		stats[STAT_HEALTH] = ent->v->health;
+		stats[STAT_WEAPON] = SV_ModelIndex(PR_GetEntityString(ent->v->weaponmodel));
+		stats[STAT_AMMO] = ent->v->currentammo;
+		stats[STAT_ARMOR] = ent->v->armorvalue;
+		stats[STAT_SHELLS] = ent->v->ammo_shells;
+		stats[STAT_NAILS] = ent->v->ammo_nails;
+		stats[STAT_ROCKETS] = ent->v->ammo_rockets;
+		stats[STAT_CELLS] = ent->v->ammo_cells;
+		stats[STAT_ACTIVEWEAPON] = ent->v->weapon;
 
-		if (ent->v.health > 0) // viewheight for PF_DEAD & PF_GIB is hardwired
-			stats[STAT_VIEWHEIGHT] = ent->v.view_ofs[2];
+		if (ent->v->health > 0) // viewheight for PF_DEAD & PF_GIB is hardwired
+			stats[STAT_VIEWHEIGHT] = ent->v->view_ofs[2];
 
 		// stuff the sigil bits into the high bits of items for sbar
-		stats[STAT_ITEMS] = (int) ent->v.items | ((int) PR_GLOBAL(serverflags) << 28);
+		stats[STAT_ITEMS] = (int) ent->v->items | ((int) PR_GLOBAL(serverflags) << 28);
 
 		for (j = 0 ; j < MAX_CL_STATS; j++)
 		{

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -580,7 +580,7 @@ void Sys_Printf (char *fmt, ...)
 	va_end (argptr);
 
 	// normalize text before add to console.
-	Q_normalizetext(text);
+	Q_normalizetext((char*)text);
 
 #ifndef _CONSOLE
 	if (!isdaemon)

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -347,7 +347,7 @@ static void Cmd_New_f (void)
 	if (sv_client->rip_vip)
 		MSG_WriteString (&sv_client->netchan.message, "");
 	else
-		MSG_WriteString (&sv_client->netchan.message, PR_GetEntityString(sv.edicts->v.message));
+		MSG_WriteString (&sv_client->netchan.message, PR_GetEntityString(sv.edicts->v->message));
 
 	// send the movevars
 	MSG_WriteFloat(&sv_client->netchan.message, movevars.gravity);
@@ -370,7 +370,7 @@ static void Cmd_New_f (void)
 
 	// send music
 	MSG_WriteByte (&sv_client->netchan.message, svc_cdtrack);
-	MSG_WriteByte (&sv_client->netchan.message, sv.edicts->v.sounds);
+	MSG_WriteByte (&sv_client->netchan.message, sv.edicts->v->sounds);
 
 	// send server info string
 	MSG_WriteByte (&sv_client->netchan.message, svc_stufftext);
@@ -656,7 +656,7 @@ static void Cmd_PreSpawn_f (void)
 
 		for (i = buf - sv.static_entity_count; i < sv.num_baseline_edicts; ++i) {
 			edict_t* svent = EDICT_NUM(i);
-			entity_state_t* s = &svent->e->baseline;
+			entity_state_t* s = &svent->e.baseline;
 
 			if (sv_client->netchan.message.cursize >= (sv_client->netchan.message.maxsize / 2)) {
 				break;
@@ -674,13 +674,13 @@ static void Cmd_PreSpawn_f (void)
 			else if (s->modelindex < 256) {
 				MSG_WriteByte(&sv_client->netchan.message, svc_spawnbaseline);
 				MSG_WriteShort(&sv_client->netchan.message, i);
-				MSG_WriteByte(&sv_client->netchan.message, svent->e->baseline.modelindex);
-				MSG_WriteByte(&sv_client->netchan.message, svent->e->baseline.frame);
-				MSG_WriteByte(&sv_client->netchan.message, svent->e->baseline.colormap);
-				MSG_WriteByte(&sv_client->netchan.message, svent->e->baseline.skinnum);
+				MSG_WriteByte(&sv_client->netchan.message, svent->e.baseline.modelindex);
+				MSG_WriteByte(&sv_client->netchan.message, svent->e.baseline.frame);
+				MSG_WriteByte(&sv_client->netchan.message, svent->e.baseline.colormap);
+				MSG_WriteByte(&sv_client->netchan.message, svent->e.baseline.skinnum);
 				for (j = 0; j < 3; j++) {
-					MSG_WriteCoord(&sv_client->netchan.message, svent->e->baseline.origin[j]);
-					MSG_WriteAngle(&sv_client->netchan.message, svent->e->baseline.angles[j]);
+					MSG_WriteCoord(&sv_client->netchan.message, svent->e.baseline.origin[j]);
+					MSG_WriteAngle(&sv_client->netchan.message, svent->e.baseline.angles[j]);
 				}
 			}
 			++buf;
@@ -825,20 +825,20 @@ static void SV_SpawnSpectator (void)
 	int i;
 	edict_t *e;
 
-	VectorClear (sv_player->v.origin);
-	VectorClear (sv_player->v.view_ofs);
-	sv_player->v.view_ofs[2] = 22;
-	sv_player->v.fixangle = true;
-	sv_player->v.movetype = MOVETYPE_NOCLIP; // progs can change this to MOVETYPE_FLY, for example
+	VectorClear (sv_player->v->origin);
+	VectorClear (sv_player->v->view_ofs);
+	sv_player->v->view_ofs[2] = 22;
+	sv_player->v->fixangle = true;
+	sv_player->v->movetype = MOVETYPE_NOCLIP; // progs can change this to MOVETYPE_FLY, for example
 
 	// search for an info_playerstart to spawn the spectator at
 	for (i=MAX_CLIENTS-1 ; i<sv.num_edicts ; i++)
 	{
 		e = EDICT_NUM(i);
-		if (!strcmp(PR_GetEntityString(e->v.classname), "info_player_start"))
+		if (!strcmp(PR_GetEntityString(e->v->classname), "info_player_start"))
 		{
-			VectorCopy (e->v.origin, sv_player->v.origin);
-			VectorCopy (e->v.angles, sv_player->v.angles);
+			VectorCopy (e->v->origin, sv_player->v->origin);
+			VectorCopy (e->v->angles, sv_player->v->angles);
 			return;
 		}
 	}
@@ -931,7 +931,7 @@ static void Cmd_Begin_f (void)
 		ent = EDICT_NUM( 1 + (sv_client - svs.clients) );
 		MSG_WriteByte (&sv_client->netchan.message, svc_setangle);
 		for (i = 0; i < 2; i++)
-			MSG_WriteAngle (&sv_client->netchan.message, ent->v.v_angle[i]);
+			MSG_WriteAngle (&sv_client->netchan.message, ent->v->v_angle[i]);
 		MSG_WriteAngle (&sv_client->netchan.message, 0);
 	}
 
@@ -1910,7 +1910,7 @@ Cmd_Kill_f
 */
 static void Cmd_Kill_f (void)
 {
-	if (sv_player->v.health <= 0)
+	if (sv_player->v->health <= 0)
 	{
 		SV_ClientPrintf (sv_client, PRINT_HIGH, "Can't suicide -- already dead!\n");
 		return;
@@ -2035,7 +2035,7 @@ static void Cmd_PTrack_f (void)
 		sv_client->spec_track = 0;
 		ent = EDICT_NUM(sv_client - svs.clients + 1);
 		tent = EDICT_NUM(0);
-		ent->v.goalentity = EDICT_TO_PROG(tent);
+		ent->v->goalentity = EDICT_TO_PROG(tent);
 		return;
 	}
 
@@ -2046,14 +2046,14 @@ static void Cmd_PTrack_f (void)
 		sv_client->spec_track = 0;
 		ent = EDICT_NUM(sv_client - svs.clients + 1);
 		tent = EDICT_NUM(0);
-		ent->v.goalentity = EDICT_TO_PROG(tent);
+		ent->v->goalentity = EDICT_TO_PROG(tent);
 		return;
 	}
 	sv_client->spec_track = i + 1; // now tracking
 
 	ent = EDICT_NUM(sv_client - svs.clients + 1);
 	tent = EDICT_NUM(i + 1);
-	ent->v.goalentity = EDICT_TO_PROG(tent);
+	ent->v->goalentity = EDICT_TO_PROG(tent);
 }
 
 /*
@@ -2504,14 +2504,14 @@ static void SetUpClientEdict (client_t *cl, edict_t *ent)
 {
 	ED_ClearEdict(ent);
 	// restore client name.
-	PR_SetEntityString(ent, ent->v.netname, cl->name);
+	PR_SetEntityString(ent, ent->v->netname, cl->name);
 	// so spec will have right goalentity - if speccing someone
 	if(cl->spectator && cl->spec_track > 0)
-		ent->v.goalentity = EDICT_TO_PROG(svs.clients[cl->spec_track-1].edict);
+		ent->v->goalentity = EDICT_TO_PROG(svs.clients[cl->spec_track-1].edict);
 
-	ent->v.colormap = NUM_FOR_EDICT(ent);
+	ent->v->colormap = NUM_FOR_EDICT(ent);
 
-	ent->v.team = 0;	// FIXME
+	ent->v->team = 0;	// FIXME
 
 	cl->entgravity = 1.0;
 	if (fofs_gravity)
@@ -3300,18 +3300,18 @@ static void AddLinksToPmove ( areanode_t *node )
 		next = l->next;
 		check = EDICT_FROM_AREA(l);
 
-		if (check->v.owner == pl)
+		if (check->v->owner == pl)
 			continue;		// player's own missile
-		if (check->v.solid == SOLID_BSP
-				|| check->v.solid == SOLID_BBOX
-				|| check->v.solid == SOLID_SLIDEBOX)
+		if (check->v->solid == SOLID_BSP
+				|| check->v->solid == SOLID_BBOX
+				|| check->v->solid == SOLID_SLIDEBOX)
 		{
 			if (check == sv_player)
 				continue;
 
 			for (i=0 ; i<3 ; i++)
-				if (check->v.absmin[i] > pmove_maxs[i]
-				|| check->v.absmax[i] < pmove_mins[i])
+				if (check->v->absmin[i] > pmove_maxs[i]
+				|| check->v->absmax[i] < pmove_mins[i])
 					break;
 			if (i != 3)
 				continue;
@@ -3320,20 +3320,20 @@ static void AddLinksToPmove ( areanode_t *node )
 			pe = &pmove.physents[pmove.numphysent];
 			pmove.numphysent++;
 
-			VectorCopy (check->v.origin, pe->origin);
+			VectorCopy (check->v->origin, pe->origin);
 			pe->info = NUM_FOR_EDICT(check);
-			if (check->v.solid == SOLID_BSP) {
-				if ((unsigned)check->v.modelindex >= MAX_MODELS)
-					SV_Error ("AddLinksToPmove: check->v.modelindex >= MAX_MODELS");
-				pe->model = sv.models[(int)(check->v.modelindex)];
+			if (check->v->solid == SOLID_BSP) {
+				if ((unsigned)check->v->modelindex >= MAX_MODELS)
+					SV_Error ("AddLinksToPmove: check->v->modelindex >= MAX_MODELS");
+				pe->model = sv.models[(int)(check->v->modelindex)];
 				if (!pe->model)
 					SV_Error ("SOLID_BSP with a non-bsp model");
 			}
 			else
 			{
 				pe->model = NULL;
-				VectorCopy (check->v.mins, pe->mins);
-				VectorCopy (check->v.maxs, pe->maxs);
+				VectorCopy (check->v->mins, pe->mins);
+				VectorCopy (check->v->maxs, pe->maxs);
 			}
 		}
 	}
@@ -3350,22 +3350,22 @@ static void AddLinksToPmove ( areanode_t *node )
 
 int SV_PMTypeForClient (client_t *cl)
 {
-	if (cl->edict->v.movetype == MOVETYPE_NOCLIP) {
+	if (cl->edict->v->movetype == MOVETYPE_NOCLIP) {
 		if (cl->extensions & Z_EXT_PM_TYPE_NEW)
 			return PM_SPECTATOR;
 		return PM_OLD_SPECTATOR;
 	}
 
-	if (cl->edict->v.movetype == MOVETYPE_FLY)
+	if (cl->edict->v->movetype == MOVETYPE_FLY)
 		return PM_FLY;
 
-	if (cl->edict->v.movetype == MOVETYPE_NONE)
+	if (cl->edict->v->movetype == MOVETYPE_NONE)
 		return PM_NONE;
 
-	if (cl->edict->v.movetype == MOVETYPE_LOCK)
+	if (cl->edict->v->movetype == MOVETYPE_LOCK)
 		return PM_LOCK;
 
-	if (cl->edict->v.health <= 0)
+	if (cl->edict->v->health <= 0)
 		return PM_DEAD;
 
 	return PM_NORMAL;
@@ -3453,11 +3453,11 @@ void SV_RunCmd (usercmd_t *ucmd, qbool inside, qbool second_attempt) //bliP: 24/
 	}
 
 	// copy humans' intentions to progs
-	sv_player->v.button0 = ucmd->buttons & 1;
-	sv_player->v.button2 = (ucmd->buttons & 2) >>1;
-	sv_player->v.button1 = (ucmd->buttons & 4) >> 2;
+	sv_player->v->button0 = ucmd->buttons & 1;
+	sv_player->v->button2 = (ucmd->buttons & 2) >>1;
+	sv_player->v->button1 = (ucmd->buttons & 4) >> 2;
 	if (ucmd->impulse)
-		sv_player->v.impulse = ucmd->impulse;
+		sv_player->v->impulse = ucmd->impulse;
 	if (fofs_movement) {
 		EdictFieldVector(sv_player, fofs_movement)[0] = ucmd->forwardmove;
 		EdictFieldVector(sv_player, fofs_movement)[1] = ucmd->sidemove;
@@ -3465,24 +3465,24 @@ void SV_RunCmd (usercmd_t *ucmd, qbool inside, qbool second_attempt) //bliP: 24/
 	}
 	//bliP: cuff
 	if (sv_client->cuff_time > realtime)
-		sv_player->v.button0 = sv_player->v.impulse = 0;
+		sv_player->v->button0 = sv_player->v->impulse = 0;
 	//<-
 
 	// clamp view angles
 	ucmd->angles[PITCH] = bound(sv_minpitch.value, ucmd->angles[PITCH], sv_maxpitch.value);
-	if (!sv_player->v.fixangle && ! second_attempt)
-		VectorCopy (ucmd->angles, sv_player->v.v_angle);
+	if (!sv_player->v->fixangle && ! second_attempt)
+		VectorCopy (ucmd->angles, sv_player->v->v_angle);
 
 	// model angles
 	// show 1/3 the pitch angle and all the roll angle
-	if (sv_player->v.health > 0)
+	if (sv_player->v->health > 0)
 	{
-		if (!sv_player->v.fixangle)
+		if (!sv_player->v->fixangle)
 		{
-			sv_player->v.angles[PITCH] = -sv_player->v.v_angle[PITCH]/3;
-			sv_player->v.angles[YAW] = sv_player->v.v_angle[YAW];
+			sv_player->v->angles[PITCH] = -sv_player->v->v_angle[PITCH]/3;
+			sv_player->v->angles[YAW] = sv_player->v->v_angle[YAW];
 		}
-		sv_player->v.angles[ROLL] = 0;
+		sv_player->v->angles[ROLL] = 0;
 	}
 
 	sv_frametime = ucmd->msec * 0.001;
@@ -3495,11 +3495,11 @@ void SV_RunCmd (usercmd_t *ucmd, qbool inside, qbool second_attempt) //bliP: 24/
 		vec3_t	oldvelocity;
 		float	old_teleport_time;
 
-		VectorCopy (sv_player->v.velocity, originalvel);
-		onground = (int) sv_player->v.flags & FL_ONGROUND;
+		VectorCopy (sv_player->v->velocity, originalvel);
+		onground = (int) sv_player->v->flags & FL_ONGROUND;
 
-		VectorCopy (sv_player->v.velocity, oldvelocity);
-		old_teleport_time = sv_player->v.teleport_time;
+		VectorCopy (sv_player->v->velocity, oldvelocity);
+		old_teleport_time = sv_player->v->teleport_time;
 
 		PR_GLOBAL(frametime) = sv_frametime;
 		pr_global_struct->time = sv.time;
@@ -3508,30 +3508,30 @@ void SV_RunCmd (usercmd_t *ucmd, qbool inside, qbool second_attempt) //bliP: 24/
 
 		if (pr_nqprogs)
 		{
-			sv_player->v.teleport_time = old_teleport_time;
-			VectorCopy (oldvelocity, sv_player->v.velocity);
+			sv_player->v->teleport_time = old_teleport_time;
+			VectorCopy (oldvelocity, sv_player->v->velocity);
 		}
 
-		if ( onground && originalvel[2] < 0 && sv_player->v.velocity[2] == 0 &&
-		     originalvel[0] == sv_player->v.velocity[0] &&
-		     originalvel[1] == sv_player->v.velocity[1] )
+		if ( onground && originalvel[2] < 0 && sv_player->v->velocity[2] == 0 &&
+		     originalvel[0] == sv_player->v->velocity[0] &&
+		     originalvel[1] == sv_player->v->velocity[1] )
 		{
 			// don't let KTeams mess with physics
-			sv_player->v.velocity[2] = originalvel[2];
+			sv_player->v->velocity[2] = originalvel[2];
 		}
 
 		SV_RunThink (sv_player);
 	}
 
 	// copy player state to pmove
-	VectorSubtract (sv_player->v.mins, player_mins, offset);
-	VectorAdd (sv_player->v.origin, offset, pmove.origin);
-	VectorCopy (sv_player->v.velocity, pmove.velocity);
-	VectorCopy (sv_player->v.v_angle, pmove.angles);
-	pmove.waterjumptime = sv_player->v.teleport_time;
+	VectorSubtract (sv_player->v->mins, player_mins, offset);
+	VectorAdd (sv_player->v->origin, offset, pmove.origin);
+	VectorCopy (sv_player->v->velocity, pmove.velocity);
+	VectorCopy (sv_player->v->v_angle, pmove.angles);
+	pmove.waterjumptime = sv_player->v->teleport_time;
 	pmove.cmd = *ucmd;
 	pmove.pm_type = SV_PMTypeForClient (sv_client);
-	pmove.onground = ((int)sv_player->v.flags & FL_ONGROUND) != 0;
+	pmove.onground = ((int)sv_player->v->flags & FL_ONGROUND) != 0;
 	pmove.jump_held = sv_client->jump_held;
 	pmove.jump_msec = 0;
 	
@@ -3565,7 +3565,7 @@ FIXME
 #ifdef USE_PR2
 	// This is a temporary hack for Frogbots, who adjust after bumping into things
 	// Better would be to provide a way to simulate a move command, but at least this doesn't require API change
-	if (blocked && !second_attempt && sv_client->isBot && sv_player->v.blocked)
+	if (blocked && !second_attempt && sv_client->isBot && sv_player->v->blocked)
 	{
 		pr_global_struct->self = EDICT_TO_PROG(sv_player);
 
@@ -3574,14 +3574,14 @@ FIXME
 		VectorCopy (pmove.velocity, pr_global_struct->trace_plane_normal);
 		if (pmove.onground)
 		{
-			pr_global_struct->trace_allsolid = (int) sv_player->v.flags | FL_ONGROUND;
+			pr_global_struct->trace_allsolid = (int) sv_player->v->flags | FL_ONGROUND;
 			pr_global_struct->trace_ent = EDICT_TO_PROG(EDICT_NUM(pmove.physents[pmove.groundent].info));
 		} else {
-			pr_global_struct->trace_allsolid = (int) sv_player->v.flags & ~FL_ONGROUND;
+			pr_global_struct->trace_allsolid = (int) sv_player->v->flags & ~FL_ONGROUND;
 		}
 
 		// Give the mod a chance to replace the command
-		PR_EdictBlocked (sv_player->v.blocked);
+		PR_EdictBlocked (sv_player->v->blocked);
 
 		// Run the command again
 		SV_RunCmd (ucmd, false, true);
@@ -3591,25 +3591,25 @@ FIXME
 
 	// get player state back out of pmove
 	sv_client->jump_held = pmove.jump_held;
-	sv_player->v.teleport_time = pmove.waterjumptime;
+	sv_player->v->teleport_time = pmove.waterjumptime;
 	if (pr_nqprogs)
-		sv_player->v.flags = ((int)sv_player->v.flags & ~FL_WATERJUMP) | (pmove.waterjumptime ? FL_WATERJUMP : 0);
-	sv_player->v.waterlevel = pmove.waterlevel;
-	sv_player->v.watertype = pmove.watertype;
+		sv_player->v->flags = ((int)sv_player->v->flags & ~FL_WATERJUMP) | (pmove.waterjumptime ? FL_WATERJUMP : 0);
+	sv_player->v->waterlevel = pmove.waterlevel;
+	sv_player->v->watertype = pmove.watertype;
 	if (pmove.onground)
 	{
-		sv_player->v.flags = (int) sv_player->v.flags | FL_ONGROUND;
-		sv_player->v.groundentity = EDICT_TO_PROG(EDICT_NUM(pmove.physents[pmove.groundent].info));
+		sv_player->v->flags = (int) sv_player->v->flags | FL_ONGROUND;
+		sv_player->v->groundentity = EDICT_TO_PROG(EDICT_NUM(pmove.physents[pmove.groundent].info));
 	} else {
-		sv_player->v.flags = (int) sv_player->v.flags & ~FL_ONGROUND;
+		sv_player->v->flags = (int) sv_player->v->flags & ~FL_ONGROUND;
 	}
 
-	VectorSubtract (pmove.origin, offset, sv_player->v.origin);
-	VectorCopy (pmove.velocity, sv_player->v.velocity);
+	VectorSubtract (pmove.origin, offset, sv_player->v->origin);
+	VectorCopy (pmove.velocity, sv_player->v->velocity);
 
-	VectorCopy (pmove.angles, sv_player->v.v_angle);
+	VectorCopy (pmove.angles, sv_player->v->v_angle);
 
-	if (sv_player->v.solid != SOLID_NOT)
+	if (sv_player->v->solid != SOLID_NOT)
 	{
 		// link into place and touch triggers
 		SV_LinkEdict (sv_player, true);
@@ -3620,11 +3620,11 @@ FIXME
 			edict_t *ent;
 			n = pmove.physents[pmove.touchindex[i]].info;
 			ent = EDICT_NUM(n);
-			if (!ent->v.touch || (playertouch[n/8]&(1<<(n%8))))
+			if (!ent->v->touch || (playertouch[n/8]&(1<<(n%8))))
 				continue;
 			pr_global_struct->self = EDICT_TO_PROG(ent);
 			pr_global_struct->other = EDICT_TO_PROG(sv_player);
-			PR_EdictTouch (ent->v.touch);
+			PR_EdictTouch (ent->v->touch);
 			playertouch[n/8] |= 1 << (n%8);
 		}
 	}
@@ -3644,21 +3644,21 @@ void SV_PostRunCmd(void)
 
 	if (!sv_client->spectator)
 	{
-		onground = (int) sv_player->v.flags & FL_ONGROUND;
+		onground = (int) sv_player->v->flags & FL_ONGROUND;
 		pr_global_struct->time = sv.time;
 		pr_global_struct->self = EDICT_TO_PROG(sv_player);
-		VectorCopy (sv_player->v.velocity, originalvel);
+		VectorCopy (sv_player->v->velocity, originalvel);
 		PR_GameClientPostThink(0);
 
-		if ( onground && originalvel[2] < 0 && sv_player->v.velocity[2] == 0
-		&& originalvel[0] == sv_player->v.velocity[0]
-		&& originalvel[1] == sv_player->v.velocity[1] ) {
+		if ( onground && originalvel[2] < 0 && sv_player->v->velocity[2] == 0
+		&& originalvel[0] == sv_player->v->velocity[0]
+		&& originalvel[1] == sv_player->v->velocity[1] ) {
 			// don't let KTeams mess with physics
-			sv_player->v.velocity[2] = originalvel[2];
+			sv_player->v->velocity[2] = originalvel[2];
 		}
 
 		if (pr_nqprogs)
-			VectorCopy (originalvel, sv_player->v.velocity);
+			VectorCopy (originalvel, sv_player->v->velocity);
 
 		if (pr_nqprogs)
 			SV_RunNQNewmis ();
@@ -3688,7 +3688,7 @@ void SV_RotateCmd(client_t* cl, usercmd_t* cmd)
 		cmd->forwardmove = result[1];
 	}
 	else {
-		cmd->angles[YAW] = (cl->edict)->v.angles[YAW];
+		cmd->angles[YAW] = (cl->edict)->v->angles[YAW];
 	}
 }
 
@@ -3804,7 +3804,7 @@ void SV_ExecuteClientMessage (client_t *cl)
 			int j;
 
 			// don't hit dead players
-			if (target_cl->state != cs_spawned || target_cl->antilag_position_next == 0 || (target_cl->spectator == 0 && target_cl->edict->v.health <= 0)) {
+			if (target_cl->state != cs_spawned || target_cl->antilag_position_next == 0 || (target_cl->spectator == 0 && target_cl->edict->v->health <= 0)) {
 				cl->laggedents[i].present = false;
 				continue;
 			}
@@ -3813,7 +3813,7 @@ void SV_ExecuteClientMessage (client_t *cl)
 
 			// target player's movement commands are late, extrapolate his position based on velocity
 			if (target_time > target_cl->localtime) {
-				VectorMA(target_cl->edict->v.origin, min(target_time - target_cl->localtime, MAX_EXTRAPOLATE), target_cl->edict->v.velocity, cl->laggedents[i].laggedpos);
+				VectorMA(target_cl->edict->v->origin, min(target_time - target_cl->localtime, MAX_EXTRAPOLATE), target_cl->edict->v->velocity, cl->laggedents[i].laggedpos);
 				continue;
 			}
 
@@ -3971,7 +3971,7 @@ void SV_ExecuteClientMessage (client_t *cl)
 			if (sv_antilag.value) {
 				if (cl->antilag_position_next == 0 || cl->antilag_positions[(cl->antilag_position_next - 1) % MAX_ANTILAG_POSITIONS].localtime < cl->localtime) {
 					cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].localtime = cl->localtime;
-					VectorCopy(cl->edict->v.origin, cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].origin);
+					VectorCopy(cl->edict->v->origin, cl->antilag_positions[cl->antilag_position_next % MAX_ANTILAG_POSITIONS].origin);
 					cl->antilag_position_next++;
 				}
 			} else {
@@ -3993,7 +3993,7 @@ void SV_ExecuteClientMessage (client_t *cl)
 			// only allowed by spectators
 			if (sv_client->spectator)
 			{
-				VectorCopy(o, sv_player->v.origin);
+				VectorCopy(o, sv_player->v->origin);
 				SV_LinkEdict(sv_player, false);
 			}
 			break;

--- a/src/world.c
+++ b/src/world.c
@@ -60,15 +60,15 @@ hull_t *SV_HullForEntity (edict_t *ent, vec3_t mins, vec3_t maxs, vec3_t offset)
 
 
 	// decide which clipping hull to use, based on the size
-	if (ent->v.solid == SOLID_BSP)
+	if (ent->v->solid == SOLID_BSP)
 	{	// explicit hulls in the BSP model
-		if (ent->v.movetype != MOVETYPE_PUSH)
+		if (ent->v->movetype != MOVETYPE_PUSH)
 			SV_Error ("SOLID_BSP without MOVETYPE_PUSH");
 
-		if ((unsigned)ent->v.modelindex >= MAX_MODELS)
+		if ((unsigned)ent->v->modelindex >= MAX_MODELS)
 			SV_Error ("SV_HullForEntity: ent.modelindex >= MAX_MODELS");
 
-		model = sv.models[(int)ent->v.modelindex];
+		model = sv.models[(int)ent->v->modelindex];
 		if (!model)
 			SV_Error ("SOLID_BSP with a non-bsp model");
 
@@ -82,16 +82,16 @@ hull_t *SV_HullForEntity (edict_t *ent, vec3_t mins, vec3_t maxs, vec3_t offset)
 
 		// calculate an offset value to center the origin
 		VectorSubtract (hull->clip_mins, mins, offset);
-		VectorAdd (offset, ent->v.origin, offset);
+		VectorAdd (offset, ent->v->origin, offset);
 	}
 	else
 	{	// create a temp hull from bounding box sizes
 
-		VectorSubtract (ent->v.mins, maxs, hullmins);
-		VectorSubtract (ent->v.maxs, mins, hullmaxs);
+		VectorSubtract (ent->v->mins, maxs, hullmins);
+		VectorSubtract (ent->v->maxs, mins, hullmaxs);
 		hull = CM_HullForBox (hullmins, hullmaxs);
 		
-		VectorCopy (ent->v.origin, offset);
+		VectorCopy (ent->v->origin, offset);
 	}
 
 
@@ -214,10 +214,10 @@ SV_UnlinkEdict
 */
 void SV_UnlinkEdict (edict_t *ent)
 {
-	if (!ent->e->area.prev)
+	if (!ent->e.area.prev)
 		return;		// not linked in anywhere
-	RemoveLink (&ent->e->area);
-	ent->e->area.prev = ent->e->area.next = NULL;
+	RemoveLink (&ent->e.area);
+	ent->e.area.prev = ent->e.area.next = NULL;
 }
 
 /*
@@ -243,15 +243,15 @@ int SV_AreaEdicts (vec3_t mins, vec3_t maxs, edict_t **edicts, int max_edicts, i
 		for (l = start->next ; l != start ; l = l->next)
 		{
 			touch = EDICT_FROM_AREA(l);
-			if (touch->v.solid == SOLID_NOT)
+			if (touch->v->solid == SOLID_NOT)
 				continue;
 
-			if (mins[0] > touch->v.absmax[0]
-						 || mins[1] > touch->v.absmax[1]
-						 || mins[2] > touch->v.absmax[2]
-						 || maxs[0] < touch->v.absmin[0]
-						 || maxs[1] < touch->v.absmin[1]
-						 || maxs[2] < touch->v.absmin[2])
+			if (mins[0] > touch->v->absmax[0]
+						 || mins[1] > touch->v->absmax[1]
+						 || mins[2] > touch->v->absmax[2]
+						 || maxs[0] < touch->v->absmin[0]
+						 || maxs[1] < touch->v->absmin[1]
+						 || maxs[2] < touch->v->absmin[2])
 				continue;
 
 			if (count == max_edicts)
@@ -300,7 +300,7 @@ static void SV_TouchLinks ( edict_t *ent, areanode_t *node )
 	edict_t		*touchlist[MAX_EDICTS], *touch;
 	int			old_self, old_other;
 
-	numtouch = SV_AreaEdicts (ent->v.absmin, ent->v.absmax, touchlist, sv.max_edicts, AREA_TRIGGERS);
+	numtouch = SV_AreaEdicts (ent->v->absmin, ent->v->absmax, touchlist, sv.max_edicts, AREA_TRIGGERS);
 
 // touch linked edicts
 	for (i = 0; i < numtouch; i++)
@@ -308,7 +308,7 @@ static void SV_TouchLinks ( edict_t *ent, areanode_t *node )
 		touch = touchlist[i];
 		if (touch == ent)
 			continue;
-		if (!touch->v.touch || touch->v.solid != SOLID_TRIGGER)
+		if (!touch->v->touch || touch->v->solid != SOLID_TRIGGER)
 			continue;
 
 		old_self = pr_global_struct->self;
@@ -317,7 +317,7 @@ static void SV_TouchLinks ( edict_t *ent, areanode_t *node )
 		pr_global_struct->self = EDICT_TO_PROG(touch);
 		pr_global_struct->other = EDICT_TO_PROG(ent);
 		pr_global_struct->time = sv.time;
-		PR_EdictTouch (touch->v.touch);
+		PR_EdictTouch (touch->v->touch);
 
 		pr_global_struct->self = old_self;
 		pr_global_struct->other = old_other;
@@ -333,11 +333,11 @@ void SV_LinkToLeafs (edict_t *ent)
 {
 	int	i, leafnums[MAX_ENT_LEAFS];
 
-	ent->e->num_leafs = CM_FindTouchedLeafs (ent->v.absmin, ent->v.absmax, leafnums,
+	ent->e.num_leafs = CM_FindTouchedLeafs (ent->v->absmin, ent->v->absmax, leafnums,
 					      MAX_ENT_LEAFS, 0, NULL);
-	for (i = 0; i < ent->e->num_leafs; i++) {
-		// ent->e->leafnums are real leafnum minus one (for pvs checks)
-		ent->e->leafnums[i] = leafnums[i] - 1;
+	for (i = 0; i < ent->e.num_leafs; i++) {
+		// ent->e.leafnums are real leafnum minus one (for pvs checks)
+		ent->e.leafnums[i] = leafnums[i] - 1;
 	}
 }
 
@@ -352,48 +352,48 @@ void SV_LinkEdict (edict_t *ent, qbool touch_triggers)
 {
 	areanode_t	*node;
 	
-	if (ent->e->area.prev)
+	if (ent->e.area.prev)
 		SV_UnlinkEdict (ent);	// unlink from old position
 		
 	if (ent == sv.edicts)
 		return;		// don't add the world
 
-	if (ent->e->free)
+	if (ent->e.free)
 		return;
 
 // set the abs box
-	VectorAdd (ent->v.origin, ent->v.mins, ent->v.absmin);
-	VectorAdd (ent->v.origin, ent->v.maxs, ent->v.absmax);
+	VectorAdd (ent->v->origin, ent->v->mins, ent->v->absmin);
+	VectorAdd (ent->v->origin, ent->v->maxs, ent->v->absmax);
 
 	//
 // to make items easier to pick up and allow them to be grabbed off
 // of shelves, the abs sizes are expanded
 	//
-	if ((int)ent->v.flags & FL_ITEM)
+	if ((int)ent->v->flags & FL_ITEM)
 	{
-		ent->v.absmin[0] -= 15;
-		ent->v.absmin[1] -= 15;
-		ent->v.absmax[0] += 15;
-		ent->v.absmax[1] += 15;
+		ent->v->absmin[0] -= 15;
+		ent->v->absmin[1] -= 15;
+		ent->v->absmax[0] += 15;
+		ent->v->absmax[1] += 15;
 	}
 	else
 	{	// because movement is clipped an epsilon away from an actual edge,
 		// we must fully check even when bounding boxes don't quite touch
-		ent->v.absmin[0] -= 1;
-		ent->v.absmin[1] -= 1;
-		ent->v.absmin[2] -= 1;
-		ent->v.absmax[0] += 1;
-		ent->v.absmax[1] += 1;
-		ent->v.absmax[2] += 1;
+		ent->v->absmin[0] -= 1;
+		ent->v->absmin[1] -= 1;
+		ent->v->absmin[2] -= 1;
+		ent->v->absmax[0] += 1;
+		ent->v->absmax[1] += 1;
+		ent->v->absmax[2] += 1;
 	}
 	
 // link to PVS leafs
-	if (ent->v.modelindex)
+	if (ent->v->modelindex)
 		SV_LinkToLeafs (ent);
 	else
-		ent->e->num_leafs = 0;
+		ent->e.num_leafs = 0;
 
-	if (ent->v.solid == SOLID_NOT)
+	if (ent->v->solid == SOLID_NOT)
 		return;
 
 // find the first node that the ent's box crosses
@@ -402,9 +402,9 @@ void SV_LinkEdict (edict_t *ent, qbool touch_triggers)
 	{
 		if (node->axis == -1)
 			break;
-		if (ent->v.absmin[node->axis] > node->dist)
+		if (ent->v->absmin[node->axis] > node->dist)
 			node = node->children[0];
-		else if (ent->v.absmax[node->axis] < node->dist)
+		else if (ent->v->absmax[node->axis] < node->dist)
 			node = node->children[1];
 		else
 			break;		// crosses the node
@@ -412,10 +412,10 @@ void SV_LinkEdict (edict_t *ent, qbool touch_triggers)
 	
 // link it in	
 
-	if (ent->v.solid == SOLID_TRIGGER)
-		InsertLinkBefore (&ent->e->area, &node->trigger_edicts);
+	if (ent->v->solid == SOLID_TRIGGER)
+		InsertLinkBefore (&ent->e.area, &node->trigger_edicts);
 	else
-		InsertLinkBefore (&ent->e->area, &node->solid_edicts);
+		InsertLinkBefore (&ent->e.area, &node->solid_edicts);
 	
 // if touch_triggers, touch all entities at this node and decend for more
 	if (touch_triggers)
@@ -457,11 +457,11 @@ edict_t	*SV_TestEntityPosition (edict_t *ent)
 {
 	trace_t	trace;
 
-	if (ent->v.solid == SOLID_TRIGGER || ent->v.solid == SOLID_NOT)
+	if (ent->v->solid == SOLID_TRIGGER || ent->v->solid == SOLID_NOT)
 		// only clip against bmodels
-		trace = SV_Trace (ent->v.origin, ent->v.mins, ent->v.maxs, ent->v.origin, MOVE_NOMONSTERS, ent);
+		trace = SV_Trace (ent->v->origin, ent->v->mins, ent->v->maxs, ent->v->origin, MOVE_NOMONSTERS, ent);
 	else
-		trace = SV_Trace (ent->v.origin, ent->v.mins, ent->v.maxs, ent->v.origin, MOVE_NORMAL, ent);
+		trace = SV_Trace (ent->v->origin, ent->v->mins, ent->v->maxs, ent->v->origin, MOVE_NORMAL, ent);
 	
 	if (trace.startsolid)
 		return sv.edicts;
@@ -535,32 +535,32 @@ void SV_ClipToLinks ( areanode_t *node, moveclip_t *clip )
 		touch = touchlist[i];
 		if (touch == clip->passedict)
 			continue;
-		if (touch->v.solid == SOLID_TRIGGER)
+		if (touch->v->solid == SOLID_TRIGGER)
 			SV_Error ("Trigger in clipping list");
 
-		if ((clip->type & MOVE_NOMONSTERS) && touch->v.solid != SOLID_BSP)
+		if ((clip->type & MOVE_NOMONSTERS) && touch->v->solid != SOLID_BSP)
 			continue;
 
-		if (clip->passedict && clip->passedict->v.size[0] && !touch->v.size[0])
+		if (clip->passedict && clip->passedict->v->size[0] && !touch->v->size[0])
 			continue;	// points never interact
 
 		if (clip->type & MOVE_LAGGED)
 		{
 			//can't touch lagged ents - we do an explicit test for them later in SV_AntilagClipCheck.
-			if (touch->e->entnum - 1 < w.maxlagents)
-				if (w.lagents[touch->e->entnum - 1].present)
+			if (touch->e.entnum - 1 < w.maxlagents)
+				if (w.lagents[touch->e.entnum - 1].present)
 					continue;
 		}
 
 		if (clip->passedict)
 		{
-			if (PROG_TO_EDICT(touch->v.owner) == clip->passedict)
+			if (PROG_TO_EDICT(touch->v->owner) == clip->passedict)
 				continue;	// don't clip against own missiles
-			if (PROG_TO_EDICT(clip->passedict->v.owner) == touch)
+			if (PROG_TO_EDICT(clip->passedict->v->owner) == touch)
 				continue;	// don't clip against owner
 		}
 
-		if ((int)touch->v.flags & FL_MONSTER)
+		if ((int)touch->v->flags & FL_MONSTER)
 			trace = SV_ClipMoveToEntity (touch, NULL, clip->start, clip->mins2, clip->maxs2, clip->end);
 		else
 			trace = SV_ClipMoveToEntity (touch, NULL, clip->start, clip->mins, clip->maxs, clip->end);
@@ -617,10 +617,10 @@ void SV_MoveBounds (vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, vec3_t b
 
 void SV_AntilagReset (edict_t *ent)
 {
-	if (ent->e->entnum == 0 || ent->e->entnum > MAX_CLIENTS)
+	if (ent->e.entnum == 0 || ent->e.entnum > MAX_CLIENTS)
 		return;
 
-	svs.clients[ent->e->entnum - 1].antilag_position_next = 0;
+	svs.clients[ent->e.entnum - 1].antilag_position_next = 0;
 }
 
 void SV_AntilagClipSetUp ( areanode_t *node, moveclip_t *clip )
@@ -629,16 +629,16 @@ void SV_AntilagClipSetUp ( areanode_t *node, moveclip_t *clip )
 
 	clip->type &= ~MOVE_LAGGED;
 
-	if (passedict->e->entnum && passedict->e->entnum <= MAX_CLIENTS)
+	if (passedict->e.entnum && passedict->e.entnum <= MAX_CLIENTS)
 	{
 		clip->type |= MOVE_LAGGED;
-		w.lagents = svs.clients[passedict->e->entnum-1].laggedents;
-		w.maxlagents = svs.clients[passedict->e->entnum-1].laggedents_count;
-		w.lagentsfrac = svs.clients[passedict->e->entnum-1].laggedents_frac;
+		w.lagents = svs.clients[passedict->e.entnum-1].laggedents;
+		w.maxlagents = svs.clients[passedict->e.entnum-1].laggedents_count;
+		w.lagentsfrac = svs.clients[passedict->e.entnum-1].laggedents_frac;
 	}
-	else if (passedict->v.owner)
+	else if (passedict->v->owner)
 	{
-		int owner = PROG_TO_EDICT(passedict->v.owner)->e->entnum;
+		int owner = PROG_TO_EDICT(passedict->v->owner)->e.entnum;
 
 		if (owner && owner <= MAX_CLIENTS)
 		{
@@ -666,38 +666,38 @@ void SV_AntilagClipCheck ( areanode_t *node, moveclip_t *clip )
 			continue;
 
 		touch = EDICT_NUM(i + 1);
-		if (touch->v.solid == SOLID_NOT)
+		if (touch->v->solid == SOLID_NOT)
 			continue;
 		if (touch == clip->passedict)
 			continue;
-		if (touch->v.solid == SOLID_TRIGGER)
-			SV_Error ("Trigger (%s) in clipping list", PR_GetEntityString(touch->v.classname));
+		if (touch->v->solid == SOLID_TRIGGER)
+			SV_Error ("Trigger (%s) in clipping list", PR_GetEntityString(touch->v->classname));
 
-		if ((clip->type & MOVE_NOMONSTERS) && touch->v.solid != SOLID_BSP)
+		if ((clip->type & MOVE_NOMONSTERS) && touch->v->solid != SOLID_BSP)
 			continue;
 
-		VectorInterpolate(touch->v.origin, w.lagentsfrac, w.lagents[i].laggedpos, lp);
+		VectorInterpolate(touch->v->origin, w.lagentsfrac, w.lagents[i].laggedpos, lp);
 
-		if (   clip->boxmins[0] > lp[0]+touch->v.maxs[0]
-			|| clip->boxmins[1] > lp[1]+touch->v.maxs[1]
-			|| clip->boxmins[2] > lp[2]+touch->v.maxs[2]
-			|| clip->boxmaxs[0] < lp[0]+touch->v.mins[0]
-			|| clip->boxmaxs[1] < lp[1]+touch->v.mins[1]
-			|| clip->boxmaxs[2] < lp[2]+touch->v.mins[2] )
+		if (   clip->boxmins[0] > lp[0]+touch->v->maxs[0]
+			|| clip->boxmins[1] > lp[1]+touch->v->maxs[1]
+			|| clip->boxmins[2] > lp[2]+touch->v->maxs[2]
+			|| clip->boxmaxs[0] < lp[0]+touch->v->mins[0]
+			|| clip->boxmaxs[1] < lp[1]+touch->v->mins[1]
+			|| clip->boxmaxs[2] < lp[2]+touch->v->mins[2] )
 			continue;
 
-		if (clip->passedict && clip->passedict->v.size[0] && !touch->v.size[0])
+		if (clip->passedict && clip->passedict->v->size[0] && !touch->v->size[0])
 			continue;	// points never interact
 
 		if (clip->passedict)
 		{
-			if (PROG_TO_EDICT(touch->v.owner) == clip->passedict)
+			if (PROG_TO_EDICT(touch->v->owner) == clip->passedict)
 				continue;	// don't clip against own missiles
-			if (PROG_TO_EDICT(clip->passedict->v.owner) == touch)
+			if (PROG_TO_EDICT(clip->passedict->v->owner) == touch)
 				continue;	// don't clip against owner
 		}
 
-		if ((int)touch->v.flags & FL_MONSTER)
+		if ((int)touch->v->flags & FL_MONSTER)
 			trace = SV_ClipMoveToEntity (touch, &lp, clip->start, clip->mins2, clip->maxs2, clip->end);
 		else
 			trace = SV_ClipMoveToEntity (touch, &lp, clip->start, clip->mins, clip->maxs, clip->end);

--- a/src/world.h
+++ b/src/world.h
@@ -51,12 +51,12 @@ void SV_ClearWorld (void);
 void SV_UnlinkEdict (edict_t *ent);
 // call before removing an entity, and before trying to move one,
 // so it doesn't clip against itself
-// flags ent->v.modified
+// flags ent->v->modified
 
 void SV_LinkEdict (edict_t *ent, qbool touch_triggers);
 // Needs to be called any time an entity changes origin, mins, maxs, or solid
-// flags ent->v.modified
-// sets ent->v.absmin and ent->v.absmax
+// flags ent->v->modified
+// sets ent->v->absmin and ent->v->absmax
 // if touchtriggers, calls prog functions for the intersected triggers
 
 int SV_PointContents (vec3_t p);


### PR DESCRIPTION
in QVM Version 16 mod must use gedict without pointer to serverside part
fix comportability with previous QVM Api versions,
fix working sv_pr2references=0 for 32 bit and QVM mode