### PR TITLE
Enable s2c packet duplication

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -235,6 +235,8 @@ typedef struct
 	double		cleartime;			// if curtime > nc->cleartime, free to go
 	double		rate;				// seconds / byte
 
+	int			dupe;				//extra packet dupes to send.
+
 	// sequencing variables
 	int			incoming_sequence;
 	int			incoming_acknowledged;

--- a/src/net_chan.c
+++ b/src/net_chan.c
@@ -301,16 +301,20 @@ void Netchan_Transmit (netchan_t *chan, int length, byte *data)
 	chan->outgoing_size[i] = send.cursize;
 	chan->outgoing_time[i] = curtime;
 
+	i = 1;
 #ifndef SERVERONLY
 	//zoid, no input in demo playback mode
 	if (!cls.demoplayback)
 #endif
-		NET_SendPacket (chan->sock, send.cursize, send.data, chan->remote_address);
+	{
+		for (i = 0; i <= chan->dupe; i++)
+			NET_SendPacket (chan->sock, send.cursize, send.data, chan->remote_address);
+	}
 
 	if (chan->cleartime < curtime)
-		chan->cleartime = curtime + send.cursize * chan->rate;
+		chan->cleartime = curtime + send.cursize*i * chan->rate;
 	else
-		chan->cleartime += send.cursize * chan->rate;
+		chan->cleartime += send.cursize*i * chan->rate;
 
 #ifndef CLIENTONLY
 	if (chan->sock == NS_SERVER && sv.paused)

--- a/src/net_chan.c
+++ b/src/net_chan.c
@@ -301,7 +301,7 @@ void Netchan_Transmit (netchan_t *chan, int length, byte *data)
 	chan->outgoing_size[i] = send.cursize;
 	chan->outgoing_time[i] = curtime;
 
-	i = 1;
+	i = 1;  //for s2c packet multiplication
 #ifndef SERVERONLY
 	//zoid, no input in demo playback mode
 	if (!cls.demoplayback)

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3083,8 +3083,8 @@ int SV_BoundRate (qbool dl, int rate)
 
 	if (rate < 500)
 		rate = 500;
-	if (rate > 100000)
-		rate = 100000;
+	if (rate > 200000)
+		rate = 200000;
 
 	return rate;
 }
@@ -3642,6 +3642,11 @@ void SV_ExtractFromUserinfo (client_t *cl, qbool namechanged)
 	// rate
 	val = Info_Get (&cl->_userinfo_ctx_, cl->download ? "drate" : "rate");
 	cl->netchan.rate = 1.0 / SV_BoundRate (cl->download != NULL, Q_atoi(*val ? val : "99999"));
+
+	//s2c packet dupes
+	val = Info_Get (&cl->_userinfo_ctx_, "dupe");
+	cl->netchan.dupe = atoi(val);
+	cl->netchan.dupe = bound(0, sv_client->netchan.dupe, 5); //0=1 packet (aka: no dupes).
 
 	// message level
 	val = Info_Get (&cl->_userinfo_ctx_, "msg");


### PR DESCRIPTION
- Feature: "qizmo" Packet Duplication by Spike
- Reasoning: minimize packet loss, improving connection from clients.
- Impacts: mvdsv (server to client - s2c - This pull request) and ezQuake (client to server - c2s - done:pullrequested)


**MVDSV implementation:**
`setinfo dupe 0-5 `
The new server cvar. A client sets a "dupe" value between 0 (no packet duplication, normal behavior) and 5 (5 packets duplicated). `setinfo dupe 1` sends one duplicated packet to the client. With higher dupe values, the default mvdsv rate limit of 50000 isn't enough for a busy fight - read nails  - (and rate cut happens). Hence the change to the hard-coded mvdsv rate limit of 100000, enabling server admins to set higher rate limit. From my tests, a value of 1 or 2 if fine for rate 50000 with lots of nails (stress test). 

**Testing**
You can see this in action with the command `showpackets 1` (this command is implemented in the netchan itself - client and server - but the outbound duplicated packets aren't shown )
` <-- is 'inbound'  |  --> is 'outbound'`
So with dupe 0 and no packetloss, you should get an equal number of --> and <-- lines
but with dupe >=1, you'll get duplicated <-- lines


This works for every client that connects to mvdsv. It doesn't matter if the client uses qwfwd or not - the packets are duplicated from the server to the client.
All this is already featured in FTE.
Credits to Spike