### PR TITLE
Fix compiler warnings on abs() and also fix empty d->name string check

### DIFF
--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -1832,7 +1832,7 @@ const char* SV_MVDDemoName(void)
 		if (d->desttype == DEST_STREAM) {
 			continue; // streams are not saved on to HDD, so ignore it...
 		}
-		if (d->name && d->name[0]) {
+		if (d->name[0] != '\0') {
 			return d->name;
 		}
 	}

--- a/src/sv_move.c
+++ b/src/sv_move.c
@@ -313,7 +313,7 @@ void SV_NewChaseDir (edict_t *actor, edict_t *enemy, float dist)
 	}
 
 	// try other directions
-	if ( ((rand()&3) & 1) ||  abs(deltay)>abs(deltax))
+	if ( ((rand()&3) & 1) ||  fabs(deltay)>fabs(deltax))
 	{
 		tdir=d[1];
 		d[1]=d[2];


### PR DESCRIPTION
This pull request removes a warning in clang:

warning: using integer absolute value function 'abs' when argument is of floating point type [-Wabsolute-value]
(in sv_move.c)

Also fixes a check for an empty string in sv_demo.c

Is this OK?