### PR TITLE
CRASH: Crashes on macOS when strlcpy into itself, use memmove

### DIFF
--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -462,7 +462,7 @@ void Sys_Printf (char *fmt, ...)
 
 		if (endpos > 0) {
 			strlcpy(line, text, len + 1);
-			strlcpy(text, endpos + 1, strlen(text) - len + 1);
+			memmove(text, endpos + 1, strlen(text) - len + 1);
 			fprintf(stdout, "[%s] %s", date.str, line);
 		} else {
 			fprintf(stdout, "[%s] %s", date.str, text);


### PR DESCRIPTION
I was seeing a crash when all players ready up on macOS. Seems to be because the `strlcpy` is copying into itself and there are special checks for that. Switch to `memmove` which does the same thing and does not crash.