### PR TITLE
CVAR: Update sv_maxping enforcement, once client has been approved do…

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -352,6 +352,7 @@ typedef struct client_s
 	int             rip_vip;
 	double          delay;
 	double          disable_updates_stop;     // Vladis
+	qbool           maxping_met;              // set if user meets maxping requirements
 	packet_t        *packets, *last_packet;
 
 	// lagged-teleport extension

--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -145,6 +145,9 @@ Check that player's ping falls below sv_maxping value
 */
 qbool PlayerCheckPing()
 {
+
+	if (sv_client->maxping_met) return true;
+
 	int maxping = Q_atof(sv_maxping.string);
 	int playerping = sv_client->frames[sv_client->netchan.incoming_acknowledged&UPDATE_MASK].ping_time * 1000;
 
@@ -153,6 +156,7 @@ qbool PlayerCheckPing()
 		SV_ClientPrintf (sv_client, PRINT_HIGH, "\nYour ping is too high for this server!  Maximum ping is set to %i, your ping is %i.\nForcing spectator.\n\n",maxping,playerping);
 		return false;
 	}
+	sv_client->maxping_met = true;
 	return true;
 }
 
@@ -185,7 +189,7 @@ static void Cmd_New_f (void)
 	{
 		MSG_WriteByte (&sv_client->netchan.message, svc_stufftext);
 		MSG_WriteString (&sv_client->netchan.message, "cmd pext\n");
-		return;	
+		return;
 	}
 
 	// do not proceed if realip is unknown


### PR DESCRIPTION
Update sv_maxping enforcement, once client has been approved do not check again.  This stops users being forced to spectator between map changes.