### PR TITLE
CSQC: Initial support. (aka antilag 1 stuffs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE USE_PR2)
 target_compile_definitions(${PROJECT_NAME} PRIVATE MVD_PEXT1_SERVERSIDEWEAPON)
 target_compile_definitions(${PROJECT_NAME} PRIVATE MVD_PEXT1_SERVERSIDEWEAPON2)
 target_compile_definitions(${PROJECT_NAME} PRIVATE FTE_PEXT2_VOICECHAT)
+target_compile_definitions(${PROJECT_NAME} PRIVATE FTE_PEXT_ACCURATETIMINGS=0x40)
 
 include (TestBigEndian)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -39,6 +39,9 @@
 const char *pr2_ent_data_ptr;
 vm_t *sv_vm = NULL;
 extern gameData_t gamedata;
+#ifdef FTE_PEXT_CSQC
+extern sizebuf_t *csqcmsgbuffer;
+#endif
 
 static int PASSFLOAT(float f)
 {
@@ -1229,9 +1232,7 @@ sizebuf_t *WriteDest2(int dest)
 		return &sv.multicast;
 
 	case MSG_CSQC:
-		// Should return a reference to the CSQC message buffer managed in sv_ents.c
-		PR2_RunError("PF_Write_*: MSG_CSQC not implemented yet.");
-		return NULL;
+		return csqcmsgbuffer;
 
 	default:
 		PR2_RunError ("WriteDest: bad destination");
@@ -2013,7 +2014,29 @@ intptr_t PF2_FS_GetFileList(char *path, char *ext,
 #ifdef FTE_PEXT_CSQC
 intptr_t EXT_SetSendNeeded(intptr_t *args)
 {
-	PR2_RunError("SetSendNeeded not implemented yet.");
+	unsigned int subject = args[1];
+	unsigned int fl = args[2];
+	unsigned int to = args[3];
+
+	if (!to)
+	{	//broadcast
+		for (to = 0; to < MAX_CLIENTS; to++)
+		{
+			svs.clients[to].csqcentitysendflags[subject] |= fl;
+		}
+	}
+	else
+	{
+		to--;
+		if (to >= MAX_CLIENTS)
+		{
+			;	//some kind of error.
+		}
+		else
+		{
+			svs.clients[to].csqcentitysendflags[subject] |= fl;
+		}
+	}
 	return 0;
 }
 #endif

--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -167,36 +167,36 @@ void PR2_CheckEmptyString(char *s)
 		PR2_RunError("Bad string");
 }
 
-void PF2_precache_sound(char *s)
+int PF2_precache_sound(char *s)
 {
 	int i;
 
-	if (sv.state != ss_loading)
-		PR2_RunError("PF_Precache_*: Precache can only be done in spawn "
-		             "functions");
 	PR2_CheckEmptyString(s);
 
 	for (i = 0; i < MAX_SOUNDS; i++)
 	{
 		if (!sv.sound_precache[i])
 		{
+			if (sv.state != ss_loading)
+			{
+				PR2_RunError("PF_Precache_*: Precache can only add new sounds in spawn "
+							 "functions");
+			}
 			sv.sound_precache[i] = s;
-			return;
+			return i;
 		}
 		if (!strcmp(sv.sound_precache[i], s))
-			return;
+			return i;
 	}
 
 	PR2_RunError ("PF_precache_sound: overflow");
+
+	return 0;
 }
 
-void PF2_precache_model(char *s)
+int PF2_precache_model(char *s)
 {
 	int 	i;
-
-	if (sv.state != ss_loading)
-		PR2_RunError("PF_Precache_*: Precache can only be done in spawn "
-		             "functions");
 
 	PR2_CheckEmptyString(s);
 
@@ -204,23 +204,26 @@ void PF2_precache_model(char *s)
 	{
 		if (!sv.model_precache[i])
 		{
+			if (sv.state != ss_loading)
+			{
+				PR2_RunError("PF_Precache_*: Precache can only add new models in spawn "
+							 "functions");
+			}
 			sv.model_precache[i] = s;
-			return;
+			return i;
 		}
 		if (!strcmp(sv.model_precache[i], s))
-			return;
+			return i;
 	}
 
 	PR2_RunError ("PF_precache_model: overflow");
+
+	return 0;
 }
 
 intptr_t PF2_precache_vwep_model(char *s)
 {
 	int 	i;
-
-	if (sv.state != ss_loading)
-		PR2_RunError("PF_Precache_*: Precache can only be done in spawn "
-		             "functions");
 
 	PR2_CheckEmptyString(s);
 
@@ -231,9 +234,16 @@ intptr_t PF2_precache_vwep_model(char *s)
 	for (i = 0; i < MAX_VWEP_MODELS; i++)
 	{
 		if (!sv.vw_model_name[i]) {
+			if (sv.state != ss_loading)
+			{
+				PR2_RunError("PF_Precache_*: Precache can only add new vweps in spawn "
+							 "functions");
+			}
 			sv.vw_model_name[i] = s;
 			return i;
 		}
+		if (!strcmp(sv.vw_model_name[i], s))
+			return i;
 	}
 	PR2_RunError ("PF_precache_vwep_model: overflow");
 	return 0;
@@ -2578,11 +2588,9 @@ intptr_t PR2_GameSystemCalls(intptr_t *args) {
 		ED_Free(VME(1));
 		return 0;
 	case G_PRECACHE_SOUND:
-		PF2_precache_sound(VMA(1));
-		return 0;
+		return PF2_precache_sound(VMA(1));
 	case G_PRECACHE_MODEL:
-		PF2_precache_model(VMA(1));
-		return 0;
+		return PF2_precache_model(VMA(1));
 	case G_LIGHTSTYLE:
 		PF2_lightstyle(args[1], VMA(2));
 		return 0;

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -498,6 +498,20 @@ void SV_FullClientUpdate (client_t *client, sizebuf_t *buf)
 	char info[MAX_EXT_INFO_STRING];
 	int i;
 
+#ifdef FTE_PEXT_CSQC
+	// Reki: resend all CSQC ents, for reasons. previously the initial CSQC ent states were being dropped for some delta reasons I think.
+	if (client->csqcactive)
+	{
+		for (i = 1; i < MAX_EDICTS; i++)
+		{
+			if (client->csqcentityscope[i] & SCOPE_WANTSEND)
+			{
+				client->csqcentitysendflags[i] = 0xFFFFFF;
+			}
+		}
+	}
+#endif
+
 	i = client - svs.clients;
 
 	//Sys_Printf("SV_FullClientUpdate:  Updated frags for client %d\n", i);

--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -3625,6 +3625,9 @@ void SV_InitLocal (void)
 #ifdef MVD_PEXT1_SERVERSIDEWEAPON2
 	svs.mvdprotocolextension1 |= MVD_PEXT1_SERVERSIDEWEAPON2;
 #endif
+#ifdef MVD_PEXT1_EZCSQC
+	svs.mvdprotocolextension1 |= MVD_PEXT1_EZCSQC;
+#endif
 
 	Info_SetValueForStarKey (svs.info, "*version", SERVER_NAME " " SERVER_VERSION, MAX_SERVERINFO_STRING);
 	Info_SetValueForStarKey (svs.info, "*z_ext", va("%i", SERVER_EXTENSIONS), MAX_SERVERINFO_STRING);


### PR DESCRIPTION
Draft PR until #145 has been merged, and a bit more functionality has been implemented.

Minimal support for client to download and execute, and notify outdated clients that they're missing out:

```objc
void(float apilevel, string enginename, float engineversion) CSQC_Init =
{
    print("Hello World\n");
}
```