### PR TITLE
Update bothdefs.h

### DIFF
--- a/src/bothdefs.h
+++ b/src/bothdefs.h
@@ -157,7 +157,7 @@ typedef unsigned char byte;
 #undef false
 
 #ifndef __cplusplus
-typedef enum qbool_e {false, true} qbool;
+typedef enum qbool_e {qfalse, qtrue} qbool;
 #else
 typedef bool qbool;
 #endif


### PR DESCRIPTION
In C, starting from the C23 standard, false is defined as a keyword, which means it cannot be used as an identifier.