### PR TITLE
DOWNLOAD: Align chunksperframe to community defaults.

### DIFF
--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -42,7 +42,7 @@ cvar_t	sv_kickuserinfospamcount = {"sv_kickuserinfospamcount", "300"};
 cvar_t	sv_maxuploadsize = {"sv_maxuploadsize", "1048576"};
 
 #ifdef FTE_PEXT_CHUNKEDDOWNLOADS
-cvar_t  sv_downloadchunksperframe = {"sv_downloadchunksperframe", "15"};
+cvar_t  sv_downloadchunksperframe = {"sv_downloadchunksperframe", "30"};
 #endif
 
 #ifdef FTE_PEXT2_VOICECHAT


### PR DESCRIPTION
This is what the client defaults to, and what the nquake-sv config defaults to.

https://github.com/nQuake/distfiles/blob/79128ad68cc0533fd4c6b32ab1819a713f2f1541/sv-configs/ktx/mvdsv.cfg#L69C11-L69C12