### PR TITLE
DEMO: Disallow hashtag in demo filename

### DIFF
--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -66,7 +66,7 @@ void CleanName_Init (void)
 	chartbl[33] = chartbl[33 + 128] = '!';
 
 	// #
-	chartbl[35] = chartbl[35 + 128] = '#';
+	// chartbl[35] = chartbl[35 + 128] = '#';
 
 	// %
 	chartbl[37] = chartbl[37 + 128] = '%';


### PR DESCRIPTION
The hashtag is problematic in the context of URLS (QTV demo listing etc) as the hashtag is considered a fragment.

**Example**: Unless urlencoded this URL doesnt work
* http://15.181.21.196:28000/demos/duel_will_smith_#16_vs_whodat[aerowalk]20251102-0522.mvd
