### PR TITLE
Fix crash when loading BSP without null terminated entity string

### DIFF
--- a/src/cmodel.c
+++ b/src/cmodel.c
@@ -603,8 +603,9 @@ static void CM_LoadEntities (byte *buffer, int length)
 		map_entitystring = NULL;
 		return;
 	}
-	map_entitystring = (char *) Hunk_AllocName (length, loadname);
+	map_entitystring = (char *) Hunk_AllocName (length + 1, loadname);
 	memcpy (map_entitystring, buffer, length);
+	map_entitystring[length] = '\0';
 }
 
 


### PR DESCRIPTION
CM_LoadEntities copied the entity lump verbatim without ensuring null termination. BSP files that lack a trailing null byte (e.g. jrdm2, jvx1, lady) caused COM_Parse to read past the buffer, crashing with garbage tokens during entity spawning.

**Testing performed:**
- Reproduced bug with jrdm2.bsp
- After patching fix into mvdsv, map now loads
- Tested loading various maps still work - dm6, dm2, dm4, dm3, end + various other maps