### PR TITLE
Add ms-precision demo start timestamp + write PausedDuration to demos

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -1034,6 +1034,7 @@ void	SV_MVDInfo_f (void);
 void	SV_LastScores_f (void);
 char*   SV_MVDName2Txt (const char *name);
 void SV_MVDEmbedInfo_f(void);
+void SV_MVDEmbedStartTimestamp(void);
 
 //
 // sv_demo_qtv.c

--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -561,7 +561,7 @@ static qbool MVD_WriteMessage (sizebuf_t *msg, byte msec)
 	return (sv.mvdrecording ? true : false);
 }
 
-static void SV_MVDWritePausedTimeToStreams(demo_frame_t* frame)
+static void SV_MVDWritePausedTime(demo_frame_t* frame)
 {
 	// When writing out a paused frame, send a packet to let QTV keep delay in sync
 	if (frame->paused) {
@@ -579,9 +579,7 @@ static void SV_MVDWritePausedTimeToStreams(demo_frame_t* frame)
 		MSG_WriteByte(&msg, duration);                                    //    13: true ms value, as demo packets will have 0
 
 		for (d = demo.dest; d; d = d->nextdest) {
-			if (d->desttype == DEST_STREAM) {
-				DemoWriteDest(msg.data, msg.cursize, d);
-			}
+			DemoWriteDest(msg.data, msg.cursize, d);
 		}
 	}
 }
@@ -624,7 +622,7 @@ static qbool SV_MVDWritePacketsEx (int num)
 		time1 = frame->time;
 		nextframe = frame;
 
-		SV_MVDWritePausedTimeToStreams(frame);
+		SV_MVDWritePausedTime(frame);
 
 		// find two frames
 		// one before the exact time (time - msec) and one after,
@@ -1315,6 +1313,7 @@ void SV_MVD_SendInitialGamestate(mvddest_t* dest)
 	// flush packet
 	SV_WriteRecordMVDMessage (&buf);
 	SZ_Clear (&buf);
+	SV_MVDEmbedStartTimestamp();
 
 	// soundlist
 	MSG_WriteByte (&buf, svc_soundlist);

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -21,12 +21,64 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #ifndef CLIENTONLY
 #include "qwsvdef.h"
+#ifndef _WIN32
+#include <sys/time.h>
+#endif
 #ifndef SERVERONLY
 #include "pcre.h"
 #endif
 
 #define MAX_DEMOINFO_SIZE (1024 * 200)
 static char chartbl[256];
+
+static uint64_t SV_TimestampMilliseconds(void)
+{
+#ifdef _WIN32
+	FILETIME ft;
+	ULARGE_INTEGER ticks;
+
+	GetSystemTimeAsFileTime(&ft);
+
+	ticks.LowPart = ft.dwLowDateTime;
+	ticks.HighPart = ft.dwHighDateTime;
+
+	return (uint64_t)((ticks.QuadPart - 116444736000000000ULL) / 10000ULL);
+#else
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+
+	return (uint64_t)tv.tv_sec * 1000ULL + (uint64_t)tv.tv_usec / 1000ULL;
+#endif
+}
+
+void SV_MVDEmbedStartTimestamp(void)
+{
+	mvdhidden_block_header_t header;
+	uint64_t timestamp_ms;
+	byte buf[8];
+	int i;
+
+	if (!sv.mvdrecording) {
+		return;
+	}
+
+	timestamp_ms = SV_TimestampMilliseconds();
+	header.length = LittleLong(8);
+	header.type_id = LittleShort(mvdhidden_demo_start_timestamp_ms);
+
+	if (!MVDWrite_HiddenBlockBegin(sizeof(header.length) + sizeof(header.type_id) + 8)) {
+		return;
+	}
+
+	for (i = 0; i < 8; ++i) {
+		buf[i] = (byte)((timestamp_ms >> (i * 8)) & 0xFF);
+	}
+
+	MVD_SZ_Write(&header.length, sizeof(header.length));
+	MVD_SZ_Write(&header.type_id, sizeof(header.type_id));
+	MVD_SZ_Write(buf, 8);
+}
 
 /*
 ====================

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -21,36 +21,12 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #ifndef CLIENTONLY
 #include "qwsvdef.h"
-#ifndef _WIN32
-#include <sys/time.h>
-#endif
 #ifndef SERVERONLY
 #include "pcre.h"
 #endif
 
 #define MAX_DEMOINFO_SIZE (1024 * 200)
 static char chartbl[256];
-
-static uint64_t SV_TimestampMilliseconds(void)
-{
-#ifdef _WIN32
-	FILETIME ft;
-	ULARGE_INTEGER ticks;
-
-	GetSystemTimeAsFileTime(&ft);
-
-	ticks.LowPart = ft.dwLowDateTime;
-	ticks.HighPart = ft.dwHighDateTime;
-
-	return (uint64_t)((ticks.QuadPart - 116444736000000000ULL) / 10000ULL);
-#else
-	struct timeval tv;
-
-	gettimeofday(&tv, NULL);
-
-	return (uint64_t)tv.tv_sec * 1000ULL + (uint64_t)tv.tv_usec / 1000ULL;
-#endif
-}
 
 void SV_MVDEmbedStartTimestamp(void)
 {
@@ -63,7 +39,7 @@ void SV_MVDEmbedStartTimestamp(void)
 		return;
 	}
 
-	timestamp_ms = SV_TimestampMilliseconds();
+	timestamp_ms = Sys_TimestampMilliseconds();
 	header.length = LittleLong(8);
 	header.type_id = LittleShort(mvdhidden_demo_start_timestamp_ms);
 

--- a/src/sv_demo_misc.c
+++ b/src/sv_demo_misc.c
@@ -31,29 +31,34 @@ static char chartbl[256];
 void SV_MVDEmbedStartTimestamp(void)
 {
 	mvdhidden_block_header_t header;
-	uint64_t timestamp_ms;
-	byte buf[8];
-	int i;
+	uint64_t v;
+	byte buf[10];
+	int len = 0;
 
 	if (!sv.mvdrecording) {
 		return;
 	}
 
-	timestamp_ms = Sys_TimestampMilliseconds();
-	header.length = LittleLong(8);
+	// ULE128-encode the millisecond timestamp: 7 data bits per byte, MSB set
+	// on every byte except the last. Aligns with the remaster's variable-length
+	// int convention and extends gracefully past 64 bits.
+	v = Sys_TimestampMilliseconds();
+	while (v >= 0x80) {
+		buf[len++] = (byte)((v & 0x7F) | 0x80);
+		v >>= 7;
+	}
+	buf[len++] = (byte)v;
+
+	header.length = LittleLong(len);
 	header.type_id = LittleShort(mvdhidden_demo_start_timestamp_ms);
 
-	if (!MVDWrite_HiddenBlockBegin(sizeof(header.length) + sizeof(header.type_id) + 8)) {
+	if (!MVDWrite_HiddenBlockBegin(sizeof(header.length) + sizeof(header.type_id) + len)) {
 		return;
-	}
-
-	for (i = 0; i < 8; ++i) {
-		buf[i] = (byte)((timestamp_ms >> (i * 8)) & 0xFF);
 	}
 
 	MVD_SZ_Write(&header.length, sizeof(header.length));
 	MVD_SZ_Write(&header.type_id, sizeof(header.type_id));
-	MVD_SZ_Write(buf, 8);
+	MVD_SZ_Write(buf, len);
 }
 
 /*

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -394,6 +394,21 @@ double Sys_DoubleTime(void)
 	return (tp.tv_sec - secbase) + tp.tv_usec / 1000000.0;
 }
 #endif
+
+/*
+================
+Sys_TimestampMilliseconds
+================
+*/
+uint64_t Sys_TimestampMilliseconds(void)
+{
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+
+	return (uint64_t)tv.tv_sec * 1000ULL + (uint64_t)tv.tv_usec / 1000ULL;
+}
+
 /*
 ================
 Sys_ConsoleInput

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -490,6 +490,24 @@ double Sys_DoubleTime (void)
 
 /*
 ================
+Sys_TimestampMilliseconds
+================
+*/
+uint64_t Sys_TimestampMilliseconds(void)
+{
+	FILETIME ft;
+	ULARGE_INTEGER ticks;
+
+	GetSystemTimeAsFileTime(&ft);
+
+	ticks.LowPart = ft.dwLowDateTime;
+	ticks.HighPart = ft.dwHighDateTime;
+
+	return (uint64_t)((ticks.QuadPart - 116444736000000000ULL) / 10000ULL);
+}
+
+/*
+================
 Sys_ConsoleInput
 ================
 */

--- a/src/sys.h
+++ b/src/sys.h
@@ -76,6 +76,8 @@ void Sys_Quit (qbool restart);
 
 double Sys_DoubleTime (void);
 
+uint64_t Sys_TimestampMilliseconds (void);
+
 char *Sys_ConsoleInput (void);
 
 //void Sys_Sleep (void);

--- a/src/sys.h
+++ b/src/sys.h
@@ -36,6 +36,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define MAX_DIRFILES 4096
 #define MAX_DEMO_NAME 196
 #include "q_platform.h"
+#include <stdint.h> // uint64_t for Sys_TimestampMilliseconds prototype below; mingw cross-compile doesn't transitively get this the way glibc does.
 
 typedef struct
 {


### PR DESCRIPTION
## Summary

Two small changes to improve external synchronization with MVD demo playback:

1. **Write PausedDuration to demo files** — mvdhidden_paused_duration (0x000A) was already generated during pauses but only sent to QTV streams. This removes the DEST_STREAM filter so it also writes to .mvd demo files. Enables parsers to calculate real-time pause durations.

2. **Embed ms-precision demo start timestamp** — writes a single hidden block (type 0x000B, mvdhidden_demo_start_timestamp_ms) containing a uint64 Unix timestamp in milliseconds at the start of every demo recording. This provides sub-second precision for the demo start time.

## Motivation

The existing serverinfo epoch field provides demo start time in whole seconds. For synchronizing external data sources (e.g. voice recordings, stream overlays) with demo playback, millisecond precision is needed. The 0-999ms truncation from whole-second epoch is the dominant source of sync error.

Pause durations were unavailable in demo files, making it impossible for parsers to calculate accurate wall-clock offsets for events occurring after a pause.

## Protocol change

Adds mvdhidden_demo_start_timestamp_ms = 0x000B to the mvdhidden enum in qwprot/src/protocol.h. This is the first free slot after the existing mvdhidden_paused_duration (0x000A). A companion PR to QW-Group/qwprot is needed.

## Changes

- src/sv_demo.c: Remove DEST_STREAM filter on PausedDuration writes. Rename SV_MVDWritePausedTimeToStreams to SV_MVDWritePausedTime. Call SV_MVDEmbedStartTimestamp() after initial gamestate flush.
- src/sv_demo_misc.c: Add SV_TimestampMilliseconds() (cross-platform: gettimeofday on Unix, GetSystemTimeAsFileTime on Windows) and SV_MVDEmbedStartTimestamp().
- src/server.h: Declare SV_MVDEmbedStartTimestamp().
- src/qwprot/src/protocol.h: Add mvdhidden_demo_start_timestamp_ms = 0x000B.

## Backwards compatibility

- Old parsers + new demos: PausedDuration blocks use existing type 0x000A. The new type 0x000B hidden block is safely skipped by parsers that dont recognize it (standard dem_multiple(0) skip behavior).
- New parsers + old demos: PausedDuration blocks absent from old demo files. Timestamp block absent. Parser handles both cases gracefully.
- No KTX changes required.

## Tested

Verified with patched MVDSV on Berlin KTX servers. Demo files confirmed to contain both the demo_start_timestamp_ms hidden block and PausedDuration blocks during game pauses.

