### PR TITLE
bothdefs.h: fix qbool typedef for C23 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ else()
 endif()
 
 ######################################################################################################
- 
+
 # Check for PCRE. if found, include it; if not found, use bundled PCRE.
 find_library(PCRE_LIBRARIES pcre)
 if(PCRE_LIBRARIES)
@@ -124,7 +124,7 @@ endif()
 ######################################################################################################
 
 # Set base compiler flags
-set(CFLAGS -Wall -std=gnu17)
+set(CFLAGS -Wall)
 set(LFLAGS)
 
 

--- a/src/bothdefs.h
+++ b/src/bothdefs.h
@@ -152,12 +152,16 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 typedef unsigned char byte;
 
+#ifndef __cplusplus
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+// C23: bool, false, true are built-in keywords; use bool directly
+typedef bool qbool;
+#else
 // KJB Undefined true and false defined in SciTech's DEBUG.H header
 #undef true
 #undef false
-
-#ifndef __cplusplus
 typedef enum qbool_e {false, true} qbool;
+#endif
 #else
 typedef bool qbool;
 #endif


### PR DESCRIPTION
GCC 15 defaults to C23, where 'false' and 'true' are built-in keywords rather than macros from <stdbool.h>.  Using them as enum constants in the qbool_e typedef therefore fails with an error.

Detect C23 via __STDC_VERSION__ >= 202311L and fall back to the standard bool type in that case, mirroring what the C++ branch already does.  Pre-C23 compilers keep the existing enum-based definition.