### PR TITLE
CMake: update minimum required version to 3.25, max to 4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.0)
+cmake_minimum_required(VERSION 3.25...4.3)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 


### PR DESCRIPTION
Silences the CMake deprecation warning about compatibility with versions older than 3.10 being removed, and documents the range of tested CMake versions using the min...max syntax.