### PR TITLE
Remove unused variables

### DIFF
--- a/src/central.c
+++ b/src/central.c
@@ -339,7 +339,7 @@ static void Web_SubmitRequestForm(const char* url, struct curl_httppost *first_f
 {
 	CURL* req = curl_easy_init();
 	web_request_data_t* data = Q_malloc(sizeof(web_request_data_t));
-	CURLFORMcode code = curl_formadd(&first_form_ptr, &last_form_ptr,
+	curl_formadd(&first_form_ptr, &last_form_ptr,
 		CURLFORM_PTRNAME, "authKey",
 		CURLFORM_COPYCONTENTS, sv_www_authkey.string,
 		CURLFORM_END
@@ -370,20 +370,19 @@ void Central_VerifyChallengeResponse(client_t* client, const char* challenge, co
 	char url[512];
 	struct curl_httppost *first_form_ptr = NULL;
 	struct curl_httppost *last_form_ptr = NULL;
-	CURLFORMcode code;
 
 	if (!sv_www_address.string[0]) {
 		SV_ClientPrintf2(client, PRINT_HIGH, "Remote logins not supported on this server\n");
 		return;
 	}
 
-	code = curl_formadd(&first_form_ptr, &last_form_ptr,
+	curl_formadd(&first_form_ptr, &last_form_ptr,
 		CURLFORM_PTRNAME, "challenge",
 		CURLFORM_COPYCONTENTS, challenge,
 		CURLFORM_END
 	);
 
-	code = curl_formadd(&first_form_ptr, &last_form_ptr,
+	curl_formadd(&first_form_ptr, &last_form_ptr,
 		CURLFORM_PTRNAME, "response",
 		CURLFORM_COPYCONTENTS, response,
 		CURLFORM_END
@@ -400,7 +399,6 @@ void Central_GenerateChallenge(client_t* client, const char* username, qbool dur
 	char url[512];
 	struct curl_httppost *first_form_ptr = NULL;
 	struct curl_httppost *last_form_ptr = NULL;
-	CURLFORMcode code;
 
 	if (!sv_www_address.string[0]) {
 		SV_ClientPrintf2(client, PRINT_HIGH, "Remote logins not supported on this server\n");
@@ -409,13 +407,13 @@ void Central_GenerateChallenge(client_t* client, const char* username, qbool dur
 
 	Web_ConstructURL(url, GENERATE_CHALLENGE_PATH, sizeof(url));
 
-	code = curl_formadd(&first_form_ptr, &last_form_ptr,
+	curl_formadd(&first_form_ptr, &last_form_ptr,
 		CURLFORM_PTRNAME, "userName",
 		CURLFORM_COPYCONTENTS, username,
 		CURLFORM_END
 	);
 
-	code = curl_formadd(&first_form_ptr, &last_form_ptr,
+	curl_formadd(&first_form_ptr, &last_form_ptr,
 		CURLFORM_PTRNAME, "status",
 		CURLFORM_COPYCONTENTS, during_login ? "0" : "1",
 		CURLFORM_END
@@ -445,7 +443,6 @@ static qbool Web_AddParametersToRequest(int first_param, struct curl_httppost** 
 
 	for (i = first_param; i < Cmd_Argc() - 1; i += 2) {
 		char encoded_value[MAX_ENCODED_STRINGLEN];
-		int encoded_length = 0;
 		int j;
 		char* name;
 		char* value;

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -451,10 +451,9 @@ Sys_Printf
 void Sys_Printf (char *fmt, ...)
 {
 	va_list     argptr;
-	char        text[4096], line[4096];
+	char        text[4096];
 	char*       startpos;
 	char*       endpos;
-	int         len;
 	date_t      date;
 
 	va_start (argptr,fmt);

--- a/src/vfs_pak.c
+++ b/src/vfs_pak.c
@@ -296,7 +296,6 @@ static void *FSPAK_LoadPackFile (vfsfile_t *file, const char *desc)
 	pack_t			*pack;
 	vfsfile_t		*packhandle;
 	dpackfile_t		info;
-	int read;
 	vfserrno_t err;
 
 	packhandle = file;
@@ -334,7 +333,7 @@ static void *FSPAK_LoadPackFile (vfsfile_t *file, const char *desc)
 	for (i=0 ; i<numpackfiles ; i++)
 	{
 		*info.name = '\0';
-		read = VFS_READ(packhandle, &info, sizeof(info), &err);
+		VFS_READ(packhandle, &info, sizeof(info), &err);
 /*
 		for (j=0 ; j<sizeof(info) ; j++)
 			CRC_ProcessByte(&crc, ((qbyte *)&info)[j]);

--- a/src/vm.c
+++ b/src/vm.c
@@ -201,9 +201,6 @@ cvar_t	vm_rtChecks		= { "vm_rtChecks", "1"};
 
 int		vm_debugLevel;
 
-// used by SV_Error to get rid of running vm's before longjmp
-static int forced_unload;
-
 struct vm_s	vmTable[ VM_COUNT ];
 void VM_VmInfo_f( void );
 void VM_VmProfile_f( void );
@@ -1352,15 +1349,6 @@ void VM_Free( vm_t *vm ) {
 	if( !vm ) {
 		return;
 	}
-
-/*	if ( vm->callLevel ) {
-		if ( !forced_unload ) {
-			SV_Error( ERR_FATAL, "VM_Free(%s) on running vm", vm->name );
-			return;
-		} else {
-			Con_Printf( "forcefully unloading %s vm\n", vm->name );
-		}
-	}*/
 
 	if ( vm->destroy )
 		vm->destroy( vm );


### PR DESCRIPTION
- vm.c: 'forced_unload' was only referenced in a commented out block. remove the dead static and the commented out code.
- sv_sys_unix.c (Sys_Printf): 'line' and 'len' were left over from an earlier version of the function and never read
- vfs_pak.c (FSPAK_LoadPackFile): 'read' was declared but never used
- central.c: drop unchecked CURLFORMcode return values from Web_SubmitRequestForm, Central_VerifyChallengeResponse and Central_GenerateChallenge; remove unused 'encoded_length' loop local