### PR TITLE
Fix code correctness warnings

### DIFF
--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1133,7 +1133,7 @@ intptr_t PF2_Find(int e, int fofs, char *str)
 		if (ed->e.free)
 			continue;
 
-		if (!(intptr_t *)((byte *)ed->v + fofs))
+		if (!*(intptr_t *)((byte *)ed->v + fofs))
 			continue;
 
 		t = VM_ArgPtr(*(intptr_t *)((char *)ed->v + fofs));

--- a/src/sv_ents.c
+++ b/src/sv_ents.c
@@ -722,7 +722,7 @@ static void SV_WritePlayersToClient (client_t *client, client_frame_t *frame, by
 		{
 			// Without PEXT_TRANS there's no PF_EXTRA_PFS, move
 			// PF_ONGROUND and PF_SOLID to their expected offsets.
-			MSG_WriteShort (msg, pflags & 0x3fff | (pflags & 0xc00000) >> 8);
+			MSG_WriteShort (msg, (pflags & 0x3fff) | ((pflags & 0xc00000) >> 8));
 		}
 #else
 		MSG_WriteShort (msg, pflags);

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -216,7 +216,7 @@ int Sys_EnumerateFiles (char *gpath, char *match, int (*func)(char *, int, void 
 		gpath = "";
 	*apath = '\0';
 
-	strncpy(apath, match, sizeof(apath));
+	strlcpy(apath, match, sizeof(apath));
 	for (s = apath+strlen(apath)-1; s >= apath; s--)
 	{
 		if (*s == '/')

--- a/src/vm.c
+++ b/src/vm.c
@@ -434,7 +434,7 @@ void VM_LoadSymbols( vm_t *vm ) {
 		char	*c;
 		void	*v;
 	} mapfile;
-	char *text_p;
+	const char *text_p;
 	//char	name[MAX_QPATH];
 	char	symbols[MAX_QPATH];
 	vmSymbol_t	**prev, *sym;


### PR DESCRIPTION
pr2_cmds.c: dereference the field pointer to check if the stored string offset is zero rather than checking the address itself, which can never be NULL (-Waddress)

sv_ents.c: add parentheses to clarify operator precedence in the bitwise expression for pflags encoding (-Wparentheses)

sv_sys_unix.c: replace strncpy with strlcpy so the destination is always null-terminated even when the source fills the buffer (-Wstringop-truncation)

vm.c: change text_p to const char* to match the return type of COM_Parse, dropping the implicit const discard (-Wdiscarded-qualifiers)