### PR TITLE
Fix Windows x64 build warnings (-Woverflow)

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -207,7 +207,7 @@ int NET_UDPSVPort (void)
 	return ntohs(net_local_sv_ipadr.port);
 }
 
-int NET_GetSocket(netsrc_t netsrc, qbool tcp)
+socket_t NET_GetSocket(netsrc_t netsrc, qbool tcp)
 {
 	if (netsrc == NS_SERVER)
 	{
@@ -971,7 +971,7 @@ void NET_SendPacket (netsrc_t netsrc, int length, void *data, netadr_t to)
 
 //=============================================================================
 
-qbool TCP_Set_KEEPALIVE(int sock)
+qbool TCP_Set_KEEPALIVE(socket_t sock)
 {
 	int		iOptVal = 1;
 
@@ -1024,10 +1024,10 @@ qbool TCP_Set_KEEPALIVE(int sock)
 	return true;
 }
 
-int TCP_OpenStream (netadr_t remoteaddr)
+socket_t TCP_OpenStream (netadr_t remoteaddr)
 {
 	unsigned long _true = true;
-	int newsocket;
+	socket_t newsocket;
 	int temp;
 	struct sockaddr_storage qs;
 
@@ -1066,9 +1066,9 @@ int TCP_OpenStream (netadr_t remoteaddr)
 	return newsocket;
 }
 
-int TCP_OpenListenSocket (unsigned short int port)
+socket_t TCP_OpenListenSocket (unsigned short int port)
 {
-	int newsocket;
+	socket_t newsocket;
 	struct sockaddr_in address = {0};
 	unsigned long nonblocking = true;
 	int i;
@@ -1131,9 +1131,9 @@ int TCP_OpenListenSocket (unsigned short int port)
 	return newsocket;
 }
 
-int UDP_OpenSocket (unsigned short int port)
+socket_t UDP_OpenSocket (unsigned short int port)
 {
-	int newsocket;
+	socket_t newsocket;
 	struct sockaddr_in address;
 	unsigned long _true = true;
 	int i;

--- a/src/net.h
+++ b/src/net.h
@@ -189,19 +189,19 @@ qbool	NET_Sleep(int msec, qbool stdinissocket);
 int		NET_UDPSVPort (void);
 
 // GETER: return client/server UDP/TCP socket.
-int		NET_GetSocket(netsrc_t netsrc, qbool tcp);
+socket_t	NET_GetSocket(netsrc_t netsrc, qbool tcp);
 
 // open server TCP socket.
 void	NET_InitServer_TCP(unsigned short int port);
 
 // UTILITY: set KEEPALIVE option on TCP socket (useful for faster timeout detection).
-qbool 	TCP_Set_KEEPALIVE(int sock);
+qbool 	TCP_Set_KEEPALIVE(socket_t sock);
 // UTILITY: open TCP socket for remove address (useful for client connection).
-int		TCP_OpenStream (netadr_t remoteaddr);
+socket_t	TCP_OpenStream (netadr_t remoteaddr);
 // UTILITY: open TCP listen socket (useful for server).
-int		TCP_OpenListenSocket (unsigned short int port);
+socket_t	TCP_OpenListenSocket (unsigned short int port);
 // UTILITY: open UDP listen socket (useful for server).
-int		UDP_OpenSocket (unsigned short int port);
+socket_t	UDP_OpenSocket (unsigned short int port);
 //============================================================================
 
 //

--- a/src/server.h
+++ b/src/server.h
@@ -603,7 +603,7 @@ typedef struct
 	socket_t		socketip;		// main server UDP socket.
 
 // TCPCONNECT -->
-	int				sockettcp;		// server TCP socket, used for QTV/TCPCONNECT.
+	socket_t		sockettcp;		// server TCP socket, used for QTV/TCPCONNECT.
 	svtcpstream_t *	tcpstreams;
 // <-- TCPCONNECT
 


### PR DESCRIPTION
Change socket function return types and svs.sockettcp from int to socket_t. On Windows x64 SOCKET is UINT_PTR (64-bit) so INVALID_SOCKET overflowed into int. On Linux it resolves to int.

svs (the only instance of server_static_t) is never serialized to disk or sent over the network, so this change should be safe.