### PR TITLE
sv_main.c: fix penfilters[] bounds check using wrong constant

### DIFF
--- a/src/sv_main.c
+++ b/src/sv_main.c
@@ -2928,7 +2928,7 @@ void SV_SavePenaltyFilter (client_t *cl, filtertype_t type, double pentime)
 			return;
 		}
 
-	if (numpenfilters == MAX_IPFILTERS)
+	if (numpenfilters == MAX_PENFILTERS)
 	{
 		return;
 	}


### PR DESCRIPTION
`penfilters[]` is sized `MAX_PENFILTERS` (512), but the bounds guard in `SV_SavePenaltyFilter` checks `numpenfilters == MAX_IPFILTERS` (1024). The sibling `ipfilters[]`/`ipvip[]` arrays correctly guard with their own size constant; `penfilters[]` was copy-pasted with the wrong one. Once 512 saved penalties accumulate, the append writes past the end of `penfilters[]`.