### PR TITLE
sv_broadcast.c: unlock broadcast_lock on broadcast-in-progress path

### DIFF
--- a/src/sv_broadcast.c
+++ b/src/sv_broadcast.c
@@ -379,7 +379,7 @@ qbool SV_Broadcast(char *message)
 	if (broadcast_in_progress)
 	{
 		SV_ClientPrintf(sv_client, PRINT_HIGH, "A broadcast is already in progress\n");
-		Sys_MutexUnlock(&servers_update_lock);
+		Sys_MutexUnlock(&broadcast_lock);
 		return false;
 	}
 


### PR DESCRIPTION
`SV_Broadcast` acquires `broadcast_lock`, but the "broadcast already in progress" early-return unlocks `servers_update_lock` instead. That leaves `broadcast_lock` held (so later broadcasts fail to acquire it) and unlocks a mutex this path never took. The normal path below unlocks `broadcast_lock` correctly.