### PR TITLE
sv_master.c: bound setmaster loop to MAX_MASTERS

### DIFF
--- a/src/sv_master.c
+++ b/src/sv_master.c
@@ -41,7 +41,7 @@ void SV_SetMaster_f (void)
 
 	memset (&master_adr, 0, sizeof(master_adr));
 
-	for (i=1 ; i<Cmd_Argc() ; i++)
+	for (i=1 ; i<Cmd_Argc() && i-1 < MAX_MASTERS ; i++)
 	{
 		if (!strcmp(Cmd_Argv(i), "none") || !NET_StringToAdr (Cmd_Argv(i), &master_adr[i-1]))
 		{


### PR DESCRIPTION
`SV_SetMaster_f` populates `master_adr[i-1]` in a loop bounded only by `Cmd_Argc()`, which can reach `MAX_ARGS` (80). `master_adr[]` is sized `MAX_MASTERS` (8), so supplying more than 8 master addresses writes past the end of the array. The sibling loops in this file (`Master_Heartbeat`, `Master_Shutdown`) already iterate with `i < MAX_MASTERS`; the populate loop had no equivalent bound. Addresses beyond `MAX_MASTERS` are now ignored.
