### PR TITLE
sv_ccmds.c: guard rm and rmdir against ".." path escape

### DIFF
--- a/src/sv_ccmds.c
+++ b/src/sv_ccmds.c
@@ -610,6 +610,7 @@ void SV_RemoveDirectory_f (void)
 	SV_ReplaceChar(dirname, '\\', '/');
 
 	if (	!strncmp(dirname, "../", 3) || strstr(dirname, "/../") || *dirname == '/'
+	        ||	!strncmp(dirname, "..", 3)
 #ifdef _WIN32
 	        ||	( dirname[1] == ':' && ((*dirname >= 'a' && *dirname <= 'z') ||
 	                                   (*dirname >= 'A' && *dirname <= 'Z'))
@@ -651,6 +652,7 @@ void SV_RemoveFile_f (void)
 	if (	!strncmp(dirname, "../", 3) || strstr(dirname, "/../")
 	        ||	*dirname == '/'             || strchr(filename, '/')
 	        ||	( (i = strlen(filename)) < 3 ? 0 : !strncmp(filename + i - 3, "/..", 4) )
+	        ||	!strncmp(dirname, "..", 3)
 #ifdef _WIN32
 	        ||	( dirname[1] == ':' && ((*dirname >= 'a' && *dirname <= 'z') ||
 	                                   (*dirname >= 'A' && *dirname <= 'Z'))


### PR DESCRIPTION
`SV_ListFiles_f` (`ls`) rejects a dirname of exactly `..` (sv_ccmds.c:547), but the sibling `SV_RemoveFile_f` (`rm`) and `SV_RemoveDirectory_f` (`rmdir`) do not. So `rm .. <token>` resolves to `Sys_remove("../<file>")` and deletes files in the parent directory, and `rmdir ..` targets the parent directory itself. This adds the same bare-`..` guard to both, matching `ls`. (`ls` also has a trailing-`/..` check; that only catches same-directory resolution like `foo/..`, not an escape, so it is omitted here.) The commands are reachable only from the console and the `master_rcon_password` tier (normal `rcon` blocks them), so this is consistency hardening rather than a remote issue.
