### PR TITLE
DEMO: fix mvdhidden_paused_duration (0x000A) hidden-block framing

### DIFF
--- a/src/sv_demo.c
+++ b/src/sv_demo.c
@@ -574,9 +574,10 @@ static void SV_MVDWritePausedTime(demo_frame_t* frame)
 		MSG_WriteByte(&msg, 0);                                           //     0: duration == 0, for demos
 		MSG_WriteByte(&msg, dem_multiple);                                //     1: target of the packet
 		MSG_WriteLong(&msg, 0);                                           //  2- 5: 0 ... demo_multiple(0) => hidden packet
-		MSG_WriteLong(&msg, LittleLong(sizeof(short) + sizeof(byte)));    //  6-10: length = <short> + <byte>
-		MSG_WriteShort(&msg, LittleShort(mvdhidden_paused_duration));     // 11-12: tell QTV how much time has really passed
-		MSG_WriteByte(&msg, duration);                                    //    13: true ms value, as demo packets will have 0
+		MSG_WriteLong(&msg, LittleLong(sizeof_mvdhidden_block_header_t_range0 + sizeof(byte)));  // hidden message payload size: [u32 length][u16 type_id] + body
+		MSG_WriteLong(&msg, LittleLong(sizeof(byte)));                    // hidden-block header: body length (one byte: msec)
+		MSG_WriteShort(&msg, LittleShort(mvdhidden_paused_duration));     // hidden-block header: type id
+		MSG_WriteByte(&msg, duration);                                    // body: true elapsed msec (demo frames carry 0)
 
 		for (d = demo.dest; d; d = d->nextdest) {
 			DemoWriteDest(msg.data, msg.cursize, d);


### PR DESCRIPTION
## Problem

`SV_MVDWritePausedTime()` writes the paused-duration hidden block (`0x000A`) without the `[u32 length]` field that `mvdhidden_block_header_t` defines and that every other hidden block emits (antilag, usercmd, and the `0x000B` demo start-timestamp block from #192). It also sizes the `dem_multiple` payload as 3 instead of 7.

A spec-compliant MVD reader walks a hidden-message payload as `[u32 length][u16 type_id][body]`. With size 3 and no length prefix it finds no valid block and drops the paused-duration silently.

This stayed hidden while the block only went to QTV streams (the stream just needs the packet to arrive to keep its delay timer alive). #192 removed the `DEST_STREAM` filter so paused-duration is written to demo files too -- so the block now lands in recordings but cannot be decoded, and #192's "write PausedDuration to demos" goal does not actually work yet. (QTV-stream consumers were affected all along.)

## Fix

Add the missing `[u32 length]` field and correct the payload size, matching the canonical `[u32 length][u16 type_id][body]` layout used by `0x000B` and the other hidden blocks.

## Verification

Recorded a KTX bot match with pauses on a server built from this branch:
- **174** paused-duration blocks now decode to correct per-frame msec values, **0 malformed**
- before the fix, sample demos had only malformed blocks (size 3, no length) -> 0 parseable
- the `0x000B` start-timestamp block is unaffected and still decodes

Assisted-by: Claude:claude-opus-4-8
