### PR TITLE
Fix path traversal in Cmd_Upload_f via FS_CreatePath

### DIFF
--- a/src/sv_user.c
+++ b/src/sv_user.c
@@ -2255,6 +2255,17 @@ static void Cmd_Upload_f (void)
 		return;
 	}
 
+	SV_ReplaceChar(sv_client->uploadfn, '\\', '/');
+	if (!strncmp(sv_client->uploadfn, "../", 3) || strstr(sv_client->uploadfn, "/../") || sv_client->uploadfn[0] == '/'
+#ifdef _WIN32
+	        || (isalpha(sv_client->uploadfn[0]) && sv_client->uploadfn[1] == ':')
+#endif
+	   )
+	{
+		Con_Printf ("Illegal upload path.\n");
+		return;
+	}
+
 	if ((f = fopen(sv_client->uploadfn, "rb")))
 	{
 		Con_Printf ("File already exists.\n");


### PR DESCRIPTION
As discussed with toma, I'm sending a PR to fix a security relevant issue. This one is less severe than the one reported against ktx as it requires access to `master_rcon_password`. In practice admins who have it are usually also maintaining the host it runs on, but it might not always be the case. 

This code line causes the security issue:
https://github.com/QW-Group/mvdsv/blob/master/src/sv_user.c#L2266

As a qw client, running

`cmd upload foo ../../../../tmp/foo/evil`

will fail because `SV_NextUpload()` validates that `sv_client->uploadfn` does not contain `../`, however `cmd_Upload_f()` calls `mkdir()` on `../../../../tmp/foo/` first, allowing anyone with the rcon master password to create arbitrary directories outside the gamedir as long as the server has write access.

Add the same path traversal checks used by SV_NextUpload (including backslash normalisation) into Cmd_Upload_f, before FS_CreatePath is called.