### PR TITLE
mathlib: fix strict-aliasing violations

### DIFF
--- a/src/mathlib.c
+++ b/src/mathlib.c
@@ -46,12 +46,13 @@ float anglemod(float a)
 
 #define VectorNormalizeFast(_v)		\
 do {								\
+	union { float f; int i; } _pun;										\
 	_mathlib_temp_float1 = DotProduct((_v), (_v));						\
 	if (_mathlib_temp_float1) {											\
 		_mathlib_temp_float2 = 0.5f * _mathlib_temp_float1;				\
-		_mathlib_temp_int1 = *((int *) &_mathlib_temp_float1);			\
-		_mathlib_temp_int1 = 0x5f375a86 - (_mathlib_temp_int1 >> 1);	\
-		_mathlib_temp_float1 = *((float *) &_mathlib_temp_int1);		\
+		_pun.f = _mathlib_temp_float1;									\
+		_pun.i = 0x5f375a86 - (_pun.i >> 1);							\
+		_mathlib_temp_float1 = _pun.f;									\
 		_mathlib_temp_float1 = _mathlib_temp_float1 * (1.5f - _mathlib_temp_float2 * _mathlib_temp_float1 * _mathlib_temp_float1);	\
 		VectorScale((_v), _mathlib_temp_float1, (_v))					\
 	}																	\

--- a/src/mathlib.h
+++ b/src/mathlib.h
@@ -47,7 +47,7 @@ extern int _mathlib_temp_int1, _mathlib_temp_int2, _mathlib_temp_int3;
 #define DEG2RAD(a) (((a) * M_PI) / 180.0F)
 
 #define NANMASK (255<<23)
-#define IS_NAN(x) (((*(int *)&x)&NANMASK)==NANMASK)
+#define IS_NAN(x) ({ union { float _f; int _i; } _u; _u._f = (x); (_u._i & NANMASK) == NANMASK; })
 
 #ifndef Q_rint
 #define Q_rint(x) ((x) > 0 ? (int)((x) + 0.5) : (int)((x) - 0.5))


### PR DESCRIPTION
VectorNormalizeFast and IS_NAN both read a float's bit pattern as an int by casting a pointer, which violates C strict-aliasing rules and produces `-Wstrict-aliasing` warnings with GCC 15. Use a type-punning union instead, which is well-defined in C99 and later.