### PR TITLE
Fix cURL build support

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -93,15 +93,37 @@ jobs:
             sudo dpkg --add-architecture ${{ matrix.arch }}
           fi
 
-          sudo apt-get ${APT_FLAGS} update
+          sudo apt-get update
 
-          sudo apt-get ${APT_FLAGS} install cmake build-essential ninja-build ${{ matrix.cross-compiler-package }} || \
+          sudo apt-get ${APT_FLAGS} install -y cmake build-essential ninja-build ${{ matrix.cross-compiler-package }}
           if [ "${{ matrix.os }}" = "linux" ]; then
-            sudo apt-get ${APT_FLAGS} --no-install-recommends install libcurl4-openssl-dev:${{ matrix.arch }}
+            sudo apt-get ${APT_FLAGS} --no-install-recommends install -y libcurl4-openssl-dev:${{ matrix.arch }}
           fi
 
       - name: Build
         run: ./build_cmake.sh ${{ matrix.target }}
+
+      - name: Validate binary
+        env:
+          BINARY: ${{ matrix.os == 'windows' && 'mvdsv.exe' || 'mvdsv' }}
+        run: |
+          TMPFILE=$(mktemp)
+          if [ "${{ matrix.os }}" = "linux" ]; then
+            echo '== Linux: Check if binary is built with curl support =='
+            readelf -d "build/${{ matrix.target }}/${BINARY}" > "${TMPFILE}"
+            grep -F 'Shared library: [libcurl.so' "${TMPFILE}" || { cat "${TMPFILE}"; exit 1; }
+          elif [ "${{ matrix.os }}" = "windows" ]; then
+            echo '== Windows: Check if .exe is a Portable Executable with MS-DOS stub =='
+            x86_64-linux-gnu-objdump -p "build/${{ matrix.target }}/${BINARY}" > "${TMPFILE}"
+            grep 'file format pei-' "${TMPFILE}" || { cat "${TMPFILE}"; exit 1; }
+          else
+            echo "I don't know what I'm building! Unknown OS."
+            exit 1
+          fi
+          if [ -n "${RUNNER_DEBUG:-}" ]; then
+            echo '== readelf/objdump output: =='
+            cat "${TMPFILE}"
+          fi
 
       - name: Create checksums
         env:

--- a/tools/cross-cmake/linux-aarch64.cmake
+++ b/tools/cross-cmake/linux-aarch64.cmake
@@ -9,7 +9,7 @@ set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search
 # programs in the host environment
-set(CMAKE_FIND_ROOT_PATH /usr/aarch64-linux-gnu)
+set(CMAKE_FIND_ROOT_PATH /usr/include/aarch64-linux-gnu /usr/lib/aarch64-linux-gnu)
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/tools/cross-cmake/linux-armhf.cmake
+++ b/tools/cross-cmake/linux-armhf.cmake
@@ -9,7 +9,7 @@ set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search
 # programs in the host environment
-set(CMAKE_FIND_ROOT_PATH /usr/arm-linux-gnueabihf)
+set(CMAKE_FIND_ROOT_PATH /usr/include/arm-linux-gnueabihf /usr/lib/arm-linux-gnueabihf)
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/tools/cross-cmake/linux-i686.cmake
+++ b/tools/cross-cmake/linux-i686.cmake
@@ -11,7 +11,7 @@ set(CMAKE_C_FLAGS "-m32 -mfpmath=sse -msse2")
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search
 # programs in the host environment
-set(CMAKE_FIND_ROOT_PATH /usr/i686-linux-gnu)
+set(CMAKE_FIND_ROOT_PATH /usr/include/i386-linux-gnu /usr/lib/i386-linux-gnu)
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
With PR #196 I accidentally disabled cURL support in the non-amd64 snapshot builds.
    
 The trailing `|| \` caused libcurl headers to only get installed if the previous command failed, which was not intended. :)
    
Also the CMAKE_FIND_ROOT_PATH is wrong on Debian machines for cross-compiling.
    
So fix it, and add a validation step in the github workflow to ensure the Linux binaries are built with cURL support.

That the "Validate binary" steps work as intended can be seen here: https://github.com/leegarrett/mvdsv/actions/runs/27420125853