### PR TITLE
sv_antilag 1: Add SetLastRuntime PR2 extension trap

### DIFF
--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -63,6 +63,7 @@ static intptr_t EXT_SetSendNeeded(intptr_t *args);
 static intptr_t EXT_MapExtFieldPtr(intptr_t *args);
 static intptr_t EXT_SetExtFieldPtr(intptr_t *args);
 static intptr_t EXT_GetExtFieldPtr(intptr_t *args);
+static intptr_t EXT_SetLastRuntime(intptr_t *args);
 struct
 {
 	char *extname;
@@ -75,6 +76,7 @@ struct
 #ifdef FTE_PEXT_CSQC
 	{"setsendneeded",		EXT_SetSendNeeded},
 #endif
+	{"SetLastRuntime",	EXT_SetLastRuntime},
 };
 ext_syscall_t ext_syscall_tbl[256];
 
@@ -2101,6 +2103,14 @@ static intptr_t EXT_MapExtFieldPtr(intptr_t *args)
 		}
 	}
 
+	return 0;
+}
+
+static intptr_t EXT_SetLastRuntime(intptr_t *args)
+{
+	int entnum = (int)args[1];
+	edict_t *ent = EDICT_NUM(entnum);
+	ent->e.lastruntime = sv.time;
 	return 0;
 }
 


### PR DESCRIPTION
## Summary

Adds a SetLastRuntime(entnum) PR2 extension trap that sets ent->e.lastruntime = sv.time from QC code.

### Why this is needed

sv_phys.c already contains:

`c
if (ent->e.lastruntime == sv.time)
    return;
`

When sv_antilag 1 is active, the ktx game code uses ntilag_lagmove_all_proj to step a projectile through the antilag rewind window and call its touch function if it hits something. After QC returns, SV_RunNewmis → SV_RunEntity runs a second physics step on the same projectile, advancing it an extra frame.

Calling SetLastRuntime(entnum) at the end of ntilag_lagmove_all_proj makes SV_RunEntity skip the projectile for this frame, preventing the double-advance.

### Implementation

`c
static intptr_t EXT_SetLastRuntime(intptr_t *args)
{
    int entnum = (int)args[1];
    edict_t *ent = EDICT_NUM(entnum);
    ent->e.lastruntime = sv.time;
    return 0;
}
`

Registered as {"SetLastRuntime", EXT_SetLastRuntime} in ext_syscalls[].

Credit: this approach is from driztf ([Iceman12k/mvdsv#1](https://github.com/Iceman12k/mvdsv/pull/1)).

### Companion PR

This is the engine side of the antilag port. The QC side is at **qw-group/ktx#451**.