### PR TITLE
FS: avoid redundant metadata lookups during file enumeration

### DIFF
--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1935,7 +1935,7 @@ intptr_t PF2_FS_GetFileList(char *path, char *ext,
 		snprintf (netpath, sizeof (netpath), "%s/%s", gpath, path);
 
 		// reg exp search...
-		dir = Sys_listdir(netpath, ext, SORT_NO);
+		dir = Sys_listdir(netpath, ext, SORT_NO_METADATA);
 
 		for (j = 0; i < list_cnt && dir.files[j].name[0]; j++, i++)
 		{

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -163,19 +163,29 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 			}
 		}
 		snprintf(pathname, sizeof(pathname), "%s/%s", path, oneentry->d_name);
-		if ((testdir = opendir(pathname)))
+		testdir = NULL;
+		if (oneentry->d_type == DT_DIR ||
+		    ((oneentry->d_type == DT_UNKNOWN || oneentry->d_type == DT_LNK) &&
+		     (testdir = opendir(pathname))))
 		{
 			dir.numdirs++;
 			list[dir.numfiles].isdir = true;
 			list[dir.numfiles].size = list[dir.numfiles].time = 0;
-			closedir(testdir);
+			if (testdir)
+				closedir(testdir);
 		}
 		else
 		{
 			list[dir.numfiles].isdir = false;
-			//list[dir.numfiles].time = Sys_FileTime(pathname);
-			dir.size +=
-				(list[dir.numfiles].size = Sys_FileSizeTime(pathname, &list[dir.numfiles].time));
+			if (sort_type == SORT_NO_METADATA)
+			{
+				list[dir.numfiles].size = list[dir.numfiles].time = 0;
+			}
+			else
+			{
+				dir.size +=
+					(list[dir.numfiles].size = Sys_FileSizeTime(pathname, &list[dir.numfiles].time));
+			}
 		}
 		strlcpy (list[dir.numfiles].name, oneentry->d_name, MAX_DEMO_NAME);
 
@@ -188,7 +198,8 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 
 	switch (sort_type)
 	{
-	case SORT_NO: break;
+	case SORT_NO:
+	case SORT_NO_METADATA: break;
 	case SORT_BY_DATE:
 		qsort((void *)list, dir.numfiles, sizeof(file_t), Sys_compare_by_date);
 		break;
@@ -253,9 +264,13 @@ int Sys_EnumerateFiles (char *gpath, char *match, int (*func)(char *, int, void 
 				snprintf(file, sizeof(file), "%s/%s", truepath, ent->d_name);
 				//would use stat, but it breaks on fat32.
 
-				if ((dir2 = opendir(file)))
+				dir2 = NULL;
+				if (ent->d_type == DT_DIR ||
+				    ((ent->d_type == DT_UNKNOWN || ent->d_type == DT_LNK) &&
+				     (dir2 = opendir(file))))
 				{
-					closedir(dir2);
+					if (dir2)
+						closedir(dir2);
 					snprintf(file, sizeof(file), "%s%s/", apath, ent->d_name);
 					//printf("is directory = %s\n", file);
 				}

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -118,7 +118,7 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 	DIR *d;
 	DIR *testdir; //bliP: list dir
 	struct dirent *oneentry;
-	qbool all;
+	qbool all, isdir;
 
 	int r;
 	pcre *preg = NULL;
@@ -164,9 +164,18 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		}
 		snprintf(pathname, sizeof(pathname), "%s/%s", path, oneentry->d_name);
 		testdir = NULL;
-		if (oneentry->d_type == DT_DIR ||
-		    ((oneentry->d_type == DT_UNKNOWN || oneentry->d_type == DT_LNK) &&
-		     (testdir = opendir(pathname))))
+		if (sort_type == SORT_NO_METADATA &&
+		    oneentry->d_type != DT_UNKNOWN && oneentry->d_type != DT_LNK)
+		{
+			isdir = oneentry->d_type == DT_DIR;
+		}
+		else
+		{
+			testdir = opendir(pathname);
+			isdir = testdir != NULL;
+		}
+
+		if (isdir)
 		{
 			dir.numdirs++;
 			list[dir.numfiles].isdir = true;
@@ -177,11 +186,7 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		else
 		{
 			list[dir.numfiles].isdir = false;
-			if (sort_type == SORT_NO_METADATA)
-			{
-				list[dir.numfiles].size = list[dir.numfiles].time = 0;
-			}
-			else
+			if (sort_type != SORT_NO_METADATA)
 			{
 				dir.size +=
 					(list[dir.numfiles].size = Sys_FileSizeTime(pathname, &list[dir.numfiles].time));
@@ -264,13 +269,9 @@ int Sys_EnumerateFiles (char *gpath, char *match, int (*func)(char *, int, void 
 				snprintf(file, sizeof(file), "%s/%s", truepath, ent->d_name);
 				//would use stat, but it breaks on fat32.
 
-				dir2 = NULL;
-				if (ent->d_type == DT_DIR ||
-				    ((ent->d_type == DT_UNKNOWN || ent->d_type == DT_LNK) &&
-				     (dir2 = opendir(file))))
+				if ((dir2 = opendir(file)))
 				{
-					if (dir2)
-						closedir(dir2);
+					closedir(dir2);
 					snprintf(file, sizeof(file), "%s%s/", apath, ent->d_name);
 					//printf("is directory = %s\n", file);
 				}

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -242,7 +242,8 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 
 	switch (sort_type)
 	{
-	case SORT_NO: break;
+	case SORT_NO:
+	case SORT_NO_METADATA: break;
 	case SORT_BY_DATE:
 		qsort((void *)list, dir.numfiles, sizeof(file_t), Sys_compare_by_date);
 		break;

--- a/src/sys.h
+++ b/src/sys.h
@@ -65,7 +65,7 @@ int		Sys_compare_by_name (const void *a, const void *b);
 #define SORT_NO			0
 #define SORT_BY_DATE	1
 #define SORT_BY_NAME	2
-#define SORT_NO_METADATA	3
+#define SORT_NO_METADATA	3 // caller does not require size/time
 
 //
 // system IO

--- a/src/sys.h
+++ b/src/sys.h
@@ -65,6 +65,7 @@ int		Sys_compare_by_name (const void *a, const void *b);
 #define SORT_NO			0
 #define SORT_BY_DATE	1
 #define SORT_BY_NAME	2
+#define SORT_NO_METADATA	3
 
 //
 // system IO


### PR DESCRIPTION
## Summary

- add a `SORT_NO_METADATA` mode for file-list callers that only need names
- use `dirent.d_type` on Unix to avoid probing entries whose type is already known
- use the new mode for `PF2_FS_GetFileList()`

## Motivation

KTX calls `FS_GetFileList` on every map change and only needs the file names. Previously, Unix enumeration attempted `opendir()` and then performed a metadata lookup for every BSP file.

With 859 maps, that resulted in 1,718 unnecessary metadata calls per map change. On FreeBSD/ZFS, the map-change delay dropped from several seconds to approximately 229 ms. This variant retains the full `FS_FlushFSHash()` on every map change and was also measured at approximately 229 ms.

Linux/ext4 was already fast, but the name-only listing itself became approximately 11 times cheaper.

## Safety

- `sv_ccmds.c` is unchanged, so the filesystem hash is still fully refreshed on every map change.
- Existing `SORT_NO`, `SORT_BY_DATE`, and `SORT_BY_NAME` callers retain the original `opendir()` and metadata lookup behavior.
- In `SORT_NO_METADATA` mode, `size`, `time`, and aggregate size remain zero-initialized. The only caller of this mode, `PF2_FS_GetFileList()`, reads only entry names.
- `DT_UNKNOWN` entries and symbolic links retain the previous safe `opendir()` fallback.
- `Sys_EnumerateFiles()` is unchanged.
- The Windows implementation recognizes the new no-sort mode while retaining its existing enumeration behavior.

## Testing

- `git diff --check`
- `cmake -S . -B build -DGIT_SUBMODULE=OFF -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --parallel 4`
