### PR TITLE
FS: avoid redundant metadata lookups during file enumeration

### DIFF
--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1935,7 +1935,7 @@ intptr_t PF2_FS_GetFileList(char *path, char *ext,
 		snprintf (netpath, sizeof (netpath), "%s/%s", gpath, path);
 
 		// reg exp search...
-		dir = Sys_listdir(netpath, ext, SORT_NO);
+		dir = Sys_listdir_no_metadata(netpath, ext);
 
 		for (j = 0; i < list_cnt && dir.files[j].name[0]; j++, i++)
 		{

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -119,7 +119,7 @@ static dir_t listdir_internal(const char *path, const char *ext,
 	DIR *d;
 	DIR *testdir; //bliP: list dir
 	struct dirent *oneentry;
-	qbool all;
+	qbool all, isdir;
 
 	int r;
 	pcre *preg = NULL;
@@ -165,12 +165,23 @@ static dir_t listdir_internal(const char *path, const char *ext,
 			}
 		}
 		snprintf(pathname, sizeof(pathname), "%s/%s", path, oneentry->d_name);
-		if ((testdir = opendir(pathname)))
+		if (oneentry->d_type != DT_UNKNOWN && oneentry->d_type != DT_LNK)
+		{
+			isdir = oneentry->d_type == DT_DIR;
+		}
+		else
+		{
+			testdir = opendir(pathname);
+			isdir = testdir != NULL;
+			if (testdir)
+				closedir(testdir);
+		}
+
+		if (isdir)
 		{
 			dir.numdirs++;
 			list[dir.numfiles].isdir = true;
 			list[dir.numfiles].size = list[dir.numfiles].time = 0;
-			closedir(testdir);
 		}
 		else
 		{

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -110,7 +110,8 @@ Sys_listdir
 ================
 */
 
-dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
+static dir_t listdir_internal(const char *path, const char *ext,
+	int sort_type, qbool read_metadata)
 {
 	static file_t list[MAX_DIRFILES];
 	dir_t dir;
@@ -128,6 +129,7 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 	memset(&dir, 0, sizeof(dir));
 
 	dir.files = list;
+	dir.is_metadata_valid = read_metadata;
 	all = !strncmp(ext, ".*", 3);
 	if (!all)
 		if (!(preg = pcre_compile(ext, PCRE_CASELESS, &errbuf, &r, NULL)))
@@ -173,9 +175,11 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		else
 		{
 			list[dir.numfiles].isdir = false;
-			//list[dir.numfiles].time = Sys_FileTime(pathname);
-			dir.size +=
-				(list[dir.numfiles].size = Sys_FileSizeTime(pathname, &list[dir.numfiles].time));
+			if (read_metadata)
+			{
+				dir.size +=
+					(list[dir.numfiles].size = Sys_FileSizeTime(pathname, &list[dir.numfiles].time));
+			}
 		}
 		strlcpy (list[dir.numfiles].name, oneentry->d_name, MAX_DEMO_NAME);
 
@@ -198,6 +202,16 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 	}
 
 	return dir;
+}
+
+dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
+{
+	return listdir_internal(path, ext, sort_type, true);
+}
+
+dir_t Sys_listdir_no_metadata (const char *path, const char *ext)
+{
+	return listdir_internal(path, ext, SORT_NO, false);
 }
 
 int Sys_EnumerateFiles (char *gpath, char *match, int (*func)(char *, int, void *), void *parm)

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -161,7 +161,8 @@ Sys_listdir
 ================
 */
 
-dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
+static dir_t listdir_internal(const char *path, const char *ext,
+	int sort_type, qbool read_metadata)
 {
 	static file_t	list[MAX_DIRFILES];
 	dir_t	dir;
@@ -178,6 +179,7 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 	memset(&dir, 0, sizeof(dir));
 
 	dir.files = list;
+	dir.is_metadata_valid = read_metadata;
 	all = !strncmp(ext, ".*", 3);
 	if (!all)
 		if (!(preg = pcre_compile(ext, PCRE_CASELESS, &errbuf, &r, NULL)))
@@ -225,9 +227,12 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		else
 		{
 			list[dir.numfiles].isdir = false;
-			snprintf(pathname, sizeof(pathname), "%s/%s", path, fd.cFileName);
-			list[dir.numfiles].time = Sys_FileTime(pathname);
-			dir.size += (list[dir.numfiles].size = fd.nFileSizeLow);
+			if (read_metadata)
+			{
+				snprintf(pathname, sizeof(pathname), "%s/%s", path, fd.cFileName);
+				list[dir.numfiles].time = Sys_FileTime(pathname);
+				dir.size += (list[dir.numfiles].size = fd.nFileSizeLow);
+			}
 		}
 		strlcpy (list[dir.numfiles].name, fd.cFileName, sizeof(list[0].name));
 
@@ -251,6 +256,16 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		break;
 	}
 	return dir;
+}
+
+dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
+{
+	return listdir_internal(path, ext, sort_type, true);
+}
+
+dir_t Sys_listdir_no_metadata (const char *path, const char *ext)
+{
+	return listdir_internal(path, ext, SORT_NO, false);
 }
 
 int Sys_EnumerateFiles (char *gpath, char *match, int (*func)(char *, int, void *), void *parm)

--- a/src/sys.h
+++ b/src/sys.h
@@ -52,6 +52,7 @@ typedef struct
 	size_t	size;
 	size_t	numfiles;
 	size_t	numdirs;
+	qbool	is_metadata_valid; // file size/time and aggregate size are valid
 } dir_t;
 
 int		Sys_FileTime (const char *path);
@@ -59,6 +60,7 @@ void	Sys_mkdir (const char *path);
 int		Sys_rmdir (const char *path);
 int		Sys_remove (const char *path);
 dir_t	Sys_listdir (const char *path, const char *ext, int sort_type);
+dir_t	Sys_listdir_no_metadata (const char *path, const char *ext);
 int		Sys_EnumerateFiles (char *gpath, char *match, int (*func)(char *, int, void *), void *parm);
 int		Sys_compare_by_date (const void *a, const void *b);
 int		Sys_compare_by_name (const void *a, const void *b);


### PR DESCRIPTION
## Summary

This replaces the earlier implementation with two narrowly scoped commits based on #225 and #223:

1. Add `Sys_listdir_no_metadata()` for `PF2_FS_GetFileList()`, which consumes names only. Add `dir_t.is_metadata_valid` so callers can distinguish valid file metadata from the intentionally omitted values.
2. In Unix directory listings, use `dirent.d_type` to avoid directory probes when the entry type is known.

## Scope

- `Sys_listdir_no_metadata()` is always unsorted and therefore has no `sort_type` argument. `SORT_BY_DATE` remains available through `Sys_listdir()`, which reads timestamps normally.
- `Sys_listdir()` returns `is_metadata_valid = true`; `Sys_listdir_no_metadata()` returns `is_metadata_valid = false`.
- Existing `Sys_listdir()` callers retain their metadata and sorting behavior. Known entry types now avoid the redundant directory probe on Unix.
- `DT_UNKNOWN` entries and symbolic links keep the existing `opendir()` fallback. The fallback directory handle is closed in the same branch that opens it.
- `Sys_EnumerateFiles()` is unchanged.
- `sv_ccmds.c` is unchanged, so `FS_FlushFSHash()` still runs on map changes.
- On Windows, only the dedicated metadata-free wrapper and validity flag are added; directory classification is unchanged.

`PF2_FS_GetFileList()` already sorts the combined list after walking all search paths, so its per-directory lookup does not need a sort mode.

## Validation

- Focused tests exercise `Sys_listdir()`, `Sys_listdir_no_metadata()`, `Sys_EnumerateFiles()`, and `PF2_FS_GetFileList()` with regular files, directories, file and directory symlinks, all existing sort modes, metadata validity and values, multiple search paths, flags, bounded buffers, duplicate removal, and traversal rejection.
- Wrapped `stat()`, `opendir()`, and `readdir()` calls verify that commit 1 removes unused metadata reads and commit 2 removes known-entry probes from both normal and metadata-free Unix listings.
- Forced `DT_UNKNOWN` runs verify the fallback behavior in both listing paths.
- Both commits build independently in a Linux release build. The final commit also builds and passes the focused harness on FreeBSD 15.1 and Debian 13.
- Real-server tests on both FreeBSD and Linux load KTX and cycle `dm6 -> aerowalk -> ztndm3` successfully for upstream, commit 1, and commit 2.
- On both systems, the traced `PF2_FS_GetFileList()` path changes from 1718 directory probes / 1718 metadata reads upstream, to 1718 / 0 after commit 1, to 0 / 0 after commit 2.
- `git diff --check` passes.

The validation harnesses are intentionally not included in the two-commit PR diff. Windows and other platform CI should still be required before merge.
