### PR TITLE
FS: skip unused metadata in FS_GetFileList

### DIFF
--- a/src/pr2_cmds.c
+++ b/src/pr2_cmds.c
@@ -1935,7 +1935,7 @@ intptr_t PF2_FS_GetFileList(char *path, char *ext,
 		snprintf (netpath, sizeof (netpath), "%s/%s", gpath, path);
 
 		// reg exp search...
-		dir = Sys_listdir(netpath, ext, SORT_NO);
+		dir = Sys_listdir_no_metadata(netpath, ext, SORT_NO);
 
 		for (j = 0; i < list_cnt && dir.files[j].name[0]; j++, i++)
 		{

--- a/src/sv_sys_unix.c
+++ b/src/sv_sys_unix.c
@@ -110,7 +110,8 @@ Sys_listdir
 ================
 */
 
-dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
+static dir_t listdir_internal(const char *path, const char *ext,
+	int sort_type, qbool read_metadata)
 {
 	static file_t list[MAX_DIRFILES];
 	dir_t dir;
@@ -173,9 +174,11 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		else
 		{
 			list[dir.numfiles].isdir = false;
-			//list[dir.numfiles].time = Sys_FileTime(pathname);
-			dir.size +=
-				(list[dir.numfiles].size = Sys_FileSizeTime(pathname, &list[dir.numfiles].time));
+			if (read_metadata)
+			{
+				dir.size +=
+					(list[dir.numfiles].size = Sys_FileSizeTime(pathname, &list[dir.numfiles].time));
+			}
 		}
 		strlcpy (list[dir.numfiles].name, oneentry->d_name, MAX_DEMO_NAME);
 
@@ -198,6 +201,16 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 	}
 
 	return dir;
+}
+
+dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
+{
+	return listdir_internal(path, ext, sort_type, true);
+}
+
+dir_t Sys_listdir_no_metadata (const char *path, const char *ext, int sort_type)
+{
+	return listdir_internal(path, ext, sort_type, false);
 }
 
 int Sys_EnumerateFiles (char *gpath, char *match, int (*func)(char *, int, void *), void *parm)

--- a/src/sv_sys_win.c
+++ b/src/sv_sys_win.c
@@ -161,7 +161,8 @@ Sys_listdir
 ================
 */
 
-dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
+static dir_t listdir_internal(const char *path, const char *ext,
+	int sort_type, qbool read_metadata)
 {
 	static file_t	list[MAX_DIRFILES];
 	dir_t	dir;
@@ -225,9 +226,12 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		else
 		{
 			list[dir.numfiles].isdir = false;
-			snprintf(pathname, sizeof(pathname), "%s/%s", path, fd.cFileName);
-			list[dir.numfiles].time = Sys_FileTime(pathname);
-			dir.size += (list[dir.numfiles].size = fd.nFileSizeLow);
+			if (read_metadata)
+			{
+				snprintf(pathname, sizeof(pathname), "%s/%s", path, fd.cFileName);
+				list[dir.numfiles].time = Sys_FileTime(pathname);
+				dir.size += (list[dir.numfiles].size = fd.nFileSizeLow);
+			}
 		}
 		strlcpy (list[dir.numfiles].name, fd.cFileName, sizeof(list[0].name));
 
@@ -251,6 +255,16 @@ dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
 		break;
 	}
 	return dir;
+}
+
+dir_t Sys_listdir (const char *path, const char *ext, int sort_type)
+{
+	return listdir_internal(path, ext, sort_type, true);
+}
+
+dir_t Sys_listdir_no_metadata (const char *path, const char *ext, int sort_type)
+{
+	return listdir_internal(path, ext, sort_type, false);
 }
 
 int Sys_EnumerateFiles (char *gpath, char *match, int (*func)(char *, int, void *), void *parm)

--- a/src/sys.h
+++ b/src/sys.h
@@ -59,6 +59,9 @@ void	Sys_mkdir (const char *path);
 int		Sys_rmdir (const char *path);
 int		Sys_remove (const char *path);
 dir_t	Sys_listdir (const char *path, const char *ext, int sort_type);
+// Supports SORT_NO and SORT_BY_NAME; file size/time and aggregate size are left zero.
+// SORT_BY_DATE requires metadata and must use Sys_listdir().
+dir_t	Sys_listdir_no_metadata (const char *path, const char *ext, int sort_type);
 int		Sys_EnumerateFiles (char *gpath, char *match, int (*func)(char *, int, void *), void *parm);
 int		Sys_compare_by_date (const void *a, const void *b);
 int		Sys_compare_by_name (const void *a, const void *b);


### PR DESCRIPTION
## Summary

Add a dedicated `Sys_listdir_no_metadata()` entry point and use it in `PF2_FS_GetFileList()`, whose output contains file names only.

Sorting and metadata collection remain separate concerns: the new entry point accepts a `sort_type`, while `PF2_FS_GetFileList()` explicitly requests `SORT_NO` because it performs its own final sort after combining search paths.

## Motivation

KTX calls `FS_GetFileList` on every map change and consumes only the returned names. The previous Unix implementation nevertheless called `Sys_FileSizeTime()` for every matching file. The Windows implementation similarly called `Sys_FileTime()`.

For a directory containing 859 BSP files, this removes 859 unused size/time lookups. On filesystems that report those entries as `DT_REG`, the companion directory-probe PR independently removes the 859 failed `opendir()` calls.

## Behavior and safety

- Existing `Sys_listdir()` callers are unchanged and continue to receive file size, modification time and aggregate directory size.
- `Sys_listdir_no_metadata()` supports `SORT_NO` and `SORT_BY_NAME`; `SORT_BY_DATE` requires metadata and continues to use `Sys_listdir()`.
- File size, modification time and aggregate size remain zero-initialized when metadata is disabled.
- `isdir` and `numdirs` are still populated using the existing platform-specific logic.
- `PF2_FS_GetFileList()` is the only caller of the new entry point and reads only `dir.files[j].name`.
- `PF2_FS_GetFileList()` passes `SORT_NO` because it sorts the combined name list itself before removing duplicates.
- `Sys_EnumerateFiles()` and its filesystem-hash behavior are unchanged.
- `sv_ccmds.c` is unchanged, so `FS_FlushFSHash()` still runs on every map change.

## Relationship to the directory-probe change

This is independent of [the companion PR that uses `dirent.d_type` to avoid redundant directory probes](https://github.com/QW-Group/mvdsv/pull/224). Either change can be merged first.

The original combined prototype was measured at approximately 229 ms on FreeBSD/ZFS, down from several seconds, with an approximately 11x cheaper Linux/ext4 name listing. This metadata-only PR has not been timed separately, so neither figure should be attributed to this PR alone.

## Testing

- `git diff --check`
- Linux release build of this branch
- clean merge with PR #224
- fresh Linux release build of the combined tree
